### PR TITLE
v1.3.0 — Cloze drills and full inflection table

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -248,10 +248,12 @@ h1::before {
  * itself doesn't flicker. */
 .challenge.card-in .word-line,
 .challenge.card-in .target-form,
+.challenge.card-in .cloze-line,
 .challenge.card-in .examples {
   animation: rise-in 240ms var(--ease) both;
 }
 .challenge.card-in .target-form { animation-delay: 40ms; }
+.challenge.card-in .cloze-line  { animation-delay: 40ms; }
 .challenge.card-in .examples    { animation-delay: 80ms; }
 .word-line {
   display: flex;
@@ -278,6 +280,47 @@ h1::before {
   color: var(--text-dim);
   letter-spacing: 0.01em;
   font-weight: 500;
+}
+
+/* The headword is a button now — tapping it opens the full inflection table.
+ * Strip the UA button chrome so it still reads as the big accent word; the
+ * dashed underline is the tap affordance. */
+button.headword {
+  background: none;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  cursor: pointer;
+  border-bottom: 1px dashed var(--border-strong);
+  transition: border-color var(--dur) var(--ease);
+}
+button.headword:hover { border-bottom-color: var(--accent); }
+
+/* Cloze prompt: an example sentence with the target form blanked out.
+ * Replaces .target-form + .examples when the Cloze drill style is active. */
+.cloze-line { margin-top: 0.9rem; }
+.cloze-fi {
+  font-size: 1.25rem;
+  color: var(--text);
+  line-height: 1.55;
+}
+.cloze-blank {
+  color: var(--accent);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  padding: 0 0.1em;
+}
+.cloze-en {
+  color: var(--muted);
+  font-size: 0.95rem;
+  margin-top: 0.5rem;
+}
+
+/* Drill style switch (Standard / Cloze) — slim centered row above the card. */
+.drill-style-row {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 0.75rem;
 }
 
 /* Speaker button — inline with the headword. */
@@ -753,6 +796,71 @@ kbd {
   gap: 0.6rem;
   margin-top: 1rem;
   flex-wrap: wrap;
+}
+
+/* ---------- Full inflection table modal ---------- */
+/* Reuses the .test-modal chrome; this inner variant is wider, left-aligned,
+ * and scrolls its body (verb paradigms are long). */
+.inflection-inner {
+  max-width: 560px;
+  text-align: left;
+}
+.inflection-inner h2 {
+  text-align: center;
+  color: var(--accent);
+}
+.inflection-note {
+  font-size: 0.8rem !important;
+  color: var(--muted) !important;
+  text-align: center;
+}
+.inflection-body {
+  max-height: 60vh;
+  overflow-y: auto;
+  margin-top: 0.6rem;
+}
+.inflection-body h3 {
+  color: var(--muted);
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin: 1rem 0 0.3rem;
+}
+.inflection-body h3:first-child { margin-top: 0; }
+.infl-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.88rem;
+}
+.infl-table th,
+.infl-table td {
+  padding: 0.32rem 0.5rem;
+  text-align: left;
+  border-top: 1px solid var(--border);
+}
+.infl-table thead th {
+  color: var(--muted);
+  font-weight: 500;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  border-top: none;
+}
+.infl-table tbody th {
+  color: var(--muted);
+  font-weight: 500;
+  white-space: nowrap;
+  width: 1%;       /* shrink to content so the form columns get the space */
+}
+.infl-table td { color: var(--text); }
+.infl-empty    { color: var(--muted-soft); }
+.infl-target   { color: var(--accent); font-weight: 600; }
+.infl-masked   { color: var(--muted); letter-spacing: 0.15em; }
+@media (max-width: 420px) {
+  .infl-table { font-size: 0.8rem; }
+  .infl-table th,
+  .infl-table td { padding: 0.26rem 0.35rem; }
 }
 
 /* Post-round summary: giant number so the result is the hero of the screen. */

--- a/index.html
+++ b/index.html
@@ -68,14 +68,31 @@
       </div>
     </header>
 
+    <!-- Drill style: Standard (lemma + grammatical prompt) vs Cloze (example
+         sentence with the form blanked out). Drill view only. -->
+    <div id="drill-style-row" class="drill-style-row hidden">
+      <div id="drill-style-switch" class="seg-switch" role="radiogroup" aria-label="Drill style">
+        <button type="button" class="seg-btn" data-value="standard" role="radio">Standard</button>
+        <button type="button" class="seg-btn" data-value="cloze"    role="radio">Cloze</button>
+      </div>
+    </div>
+
     <section id="challenge" class="panel challenge hidden">
       <div class="word-line">
-        <span id="headword" class="headword">&mdash;</span>
+        <button id="headword" type="button" class="headword"
+                title="Show all forms of this word">&mdash;</button>
         <button id="speak-headword" type="button" class="speak-btn"
                 title="Hear the lemma" aria-label="Speak lemma">&#128266;</button>
         <span id="translation" class="translation"></span>
       </div>
       <div id="target-form" class="target-form">&mdash;</div>
+      <!-- Cloze prompt: the example sentence with the target form blanked,
+           plus its English translation. Replaces #target-form + #examples
+           when the Cloze drill style is active. -->
+      <div id="cloze-line" class="cloze-line hidden">
+        <div id="cloze-fi" class="cloze-fi"></div>
+        <div id="cloze-en" class="cloze-en"></div>
+      </div>
       <ul id="examples" class="examples hidden"></ul>
     </section>
 
@@ -111,6 +128,23 @@
         </button>
       </div>
     </section>
+
+    <!-- Full inflection table for the current word, opened by tapping the
+         headword. Until the challenge is answered, cells matching the current
+         answer are masked so the table can't be used as a free reveal. -->
+    <div id="inflection-modal" class="test-modal hidden" role="dialog" aria-labelledby="inflection-title" aria-modal="true">
+      <div class="test-modal-inner inflection-inner">
+        <h2 id="inflection-title">&mdash;</h2>
+        <p id="inflection-note" class="inflection-note">
+          &bull;&bull;&bull; cells match the current answer and stay hidden
+          until you've answered.
+        </p>
+        <div id="inflection-body" class="inflection-body"></div>
+        <div class="test-modal-actions">
+          <button id="inflection-close" type="button" class="mode-btn">Close</button>
+        </div>
+      </div>
+    </div>
 
     <!-- Test in-progress strip: shown only while a test is running. Holds the
          "Question X of Y" counter and a Cancel button. Idle and result states
@@ -263,6 +297,28 @@
           verb type (1&ndash;6).
         </li>
       </ul>
+
+      <h3>Drill styles</h3>
+      <p>
+        The switch above the drill card picks how challenges are presented.
+        <strong>Standard</strong> shows the lemma plus a grammatical prompt
+        (&ldquo;inessive singular&rdquo;) and you type the form.
+        <strong>Cloze</strong> flips it: you get a real example sentence with
+        the inflected form blanked out, plus its English translation, and you
+        reconstruct the missing form from context &mdash; no case or tense
+        label to lean on. Cloze only draws on words whose example sentences
+        actually contain the target form, so its pool is smaller than
+        Standard's; your case, type, and frequency filters still apply.
+      </p>
+
+      <h3>Full inflection table</h3>
+      <p>
+        Tap the headword on any challenge to open the complete declension or
+        conjugation table for that word. Until you've answered, any cell that
+        matches the current answer is masked, so peeking at the paradigm
+        doesn't spoil the form you're being asked for. Not available during
+        tests or Blitz rounds.
+      </p>
 
       <h3>Filter presets</h3>
       <p>

--- a/js/drill.js
+++ b/js/drill.js
@@ -252,3 +252,95 @@ export function checkAnswer(challenge, input) {
   const ok = normalize(input) === normalize(expected);
   return { ok, expected, normalizedInput: normalize(input) };
 }
+
+// ---------- cloze ----------
+// A cloze challenge shows one of the word's example sentences with the
+// inflected form blanked out — the user reconstructs the form from sentence
+// context instead of a grammatical prompt. Pool entries gain an
+// `exampleIndex` pointing at the example that contains the target form.
+
+// Per-word cache of normalized example sentences so buildClozePool stays
+// O(pool): without it we'd re-normalize the same handful of sentences once
+// per inflection key (133 keys per verb). WeakMap keys on the word object,
+// so a data reload drops the cache automatically.
+const normExampleCache = new WeakMap();
+
+function normalizedExamples(word) {
+  let cached = normExampleCache.get(word);
+  if (cached) return cached;
+  cached = (word.examples || []).map((ex) => {
+    const fi = typeof ex === "string" ? ex : ex && ex.fi;
+    return fi ? normalize(fi) : null;
+  });
+  normExampleCache.set(word, cached);
+  return cached;
+}
+
+function isLetterChar(ch) {
+  return !!ch && /\p{L}/u.test(ch);
+}
+
+// Whole-word containment on normalized strings. indexOf is the hot path
+// (runs for every pool entry); the per-char boundary test only runs on
+// candidate hits. Boundaries are "not a letter" rather than \b so Finnish
+// diacritics don't split words — same semantics as the spoiler filter.
+function containsWholeWord(haystack, needle) {
+  let idx = 0;
+  while ((idx = haystack.indexOf(needle, idx)) !== -1) {
+    const before = idx > 0 ? haystack[idx - 1] : "";
+    const after = haystack[idx + needle.length] || "";
+    if (!isLetterChar(before) && !isLetterChar(after)) return idx;
+    idx += 1;
+  }
+  return -1;
+}
+
+function findClozeExampleIndex(word, key) {
+  const form = word.inflections[key];
+  if (!form) return -1;
+  const needle = normalize(form);
+  const exs = normalizedExamples(word);
+  for (let i = 0; i < exs.length; i++) {
+    if (exs[i] && containsWholeWord(exs[i], needle) !== -1) return i;
+  }
+  return -1;
+}
+
+/**
+ * Filter a standard pool down to cloze-able challenges: entries whose word
+ * has an example sentence containing the target form as a whole word.
+ * Multi-word forms (negative verbs like "en voinut") match across spaces.
+ */
+export function buildClozePool(pool) {
+  const out = [];
+  // Identical surface forms under different keys (voi = present 3sg, past
+  // 3sg, imperative 2sg…) would otherwise produce the same on-screen
+  // challenge several times over, so dedupe on what the user actually sees.
+  const seen = new Set();
+  for (const { word, key } of pool) {
+    // Skip the nominative singular: its blank is just the headword already
+    // shown in the hint line, so typing it teaches nothing.
+    if (key === "nominative_singular") continue;
+    const exampleIndex = findClozeExampleIndex(word, key);
+    if (exampleIndex < 0) continue;
+    const dedupeKey = `${word.word}|${exampleIndex}|${normalize(word.inflections[key])}`;
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+    out.push({ word, key, exampleIndex });
+  }
+  return out;
+}
+
+/**
+ * Regex matching `form` as a whole word in original (non-normalized) text.
+ * Used to locate the blank when rendering a cloze sentence: case-insensitive,
+ * Unicode-aware boundaries, tolerant of typographic apostrophes and flexible
+ * whitespace inside multi-word forms.
+ */
+export function clozeBlankRegex(form) {
+  const esc = form
+    .replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+    .replace(/'/g, "['‘’‚‛ʼ´`]")
+    .replace(/ /g, "\\s+");
+  return new RegExp(`(?<!\\p{L})${esc}(?!\\p{L})`, "giu");
+}

--- a/js/main.js
+++ b/js/main.js
@@ -3,7 +3,10 @@
 
 import { loadConfig } from "./config.js";
 import { loadData } from "./data.js";
-import { buildNounPool, buildVerbPool, nextChallenge, checkAnswer } from "./drill.js";
+import {
+  buildNounPool, buildVerbPool, nextChallenge, checkAnswer,
+  buildClozePool, clozeBlankRegex, parseVerbKey,
+} from "./drill.js";
 import { nounLabel, verbLabel } from "./labels.js";
 import {
   loadNounFilters, saveNounFilters, renderNounFilters,
@@ -104,6 +107,16 @@ const el = {
   headword:        document.getElementById("headword"),
   translation:     document.getElementById("translation"),
   targetForm:      document.getElementById("target-form"),
+  drillStyleRow:   document.getElementById("drill-style-row"),
+  drillStyleSwitch: document.getElementById("drill-style-switch"),
+  clozeLine:       document.getElementById("cloze-line"),
+  clozeFi:         document.getElementById("cloze-fi"),
+  clozeEn:         document.getElementById("cloze-en"),
+  inflectionModal: document.getElementById("inflection-modal"),
+  inflectionTitle: document.getElementById("inflection-title"),
+  inflectionNote:  document.getElementById("inflection-note"),
+  inflectionBody:  document.getElementById("inflection-body"),
+  inflectionClose: document.getElementById("inflection-close"),
   answer:          document.getElementById("answer"),
   submitAnswer:    document.getElementById("submit-answer"),
   feedback:        document.getElementById("feedback"),
@@ -180,9 +193,21 @@ function render() {
   const { word, key } = state.current;
   el.headword.textContent = word.word;
   el.translation.textContent = (word.translations || []).slice(0, 2).join(", ");
-  const label = state.mode === "noun" ? nounLabel(key, state.cfg) : verbLabel(key, state.cfg);
-  el.targetForm.textContent = label;
-  renderExamples(word, word.inflections[key]);
+  // Cloze style replaces the grammatical prompt + examples with the blanked
+  // sentence. Falls back to the standard prompt if the blank can't be
+  // located in the original text (shouldn't happen — the pool builder
+  // verified containment on the normalized form — but belt + braces).
+  const cloze = clozeActive() && renderClozeLine();
+  el.targetForm.classList.toggle("hidden", !!cloze);
+  el.clozeLine.classList.toggle("hidden", !cloze);
+  if (cloze) {
+    el.examples.innerHTML = "";
+    el.examples.classList.add("hidden");
+  } else {
+    const label = state.mode === "noun" ? nounLabel(key, state.cfg) : verbLabel(key, state.cfg);
+    el.targetForm.textContent = label;
+    renderExamples(word, word.inflections[key]);
+  }
   // Only reveal the challenge/answer row when we're actually on the drill
   // view. Some settings (excludeLong, maxAnswerLength, frequencyCap) rebuild
   // the pool as a side effect, and without this guard the challenge would
@@ -252,6 +277,61 @@ function renderExamples(word, targetForm) {
   el.examples.classList.remove("hidden");
 }
 
+// ---------- cloze rendering ----------
+function clozeActive() {
+  return !!(state.settings && state.settings.drillStyle === "cloze");
+}
+
+// Build the blanked sentence into #cloze-fi. Returns false when the current
+// challenge has no usable example (caller falls back to the standard prompt).
+// Every whole-word occurrence of the target form is blanked, not just the
+// first — leaving a later occurrence visible would spoil the answer.
+function renderClozeLine() {
+  const { word, key, exampleIndex } = state.current;
+  if (typeof exampleIndex !== "number" || exampleIndex < 0) return false;
+  const ex = (word.examples || [])[exampleIndex];
+  const fi = typeof ex === "string" ? ex : ex && ex.fi;
+  const en = typeof ex === "string" ? "" : (ex && ex.en) || "";
+  const expected = word.inflections[key];
+  if (!fi || !expected) return false;
+
+  const re = clozeBlankRegex(expected);
+  el.clozeFi.innerHTML = "";
+  let lastIdx = 0;
+  let found = false;
+  let m;
+  while ((m = re.exec(fi)) !== null) {
+    found = true;
+    if (m.index > lastIdx) {
+      el.clozeFi.appendChild(document.createTextNode(fi.slice(lastIdx, m.index)));
+    }
+    const blank = document.createElement("span");
+    blank.className = "cloze-blank";
+    blank.textContent = "_____";
+    el.clozeFi.appendChild(blank);
+    lastIdx = m.index + m[0].length;
+  }
+  if (!found) return false;
+  if (lastIdx < fi.length) {
+    el.clozeFi.appendChild(document.createTextNode(fi.slice(lastIdx)));
+  }
+  el.clozeEn.textContent = en;
+  el.clozeEn.classList.toggle("hidden", !en);
+  return true;
+}
+
+// Fill the blank(s) with the answer once the challenge resolves, so the user
+// sees the completed sentence while the feedback line is on screen. No-op in
+// standard style or when nothing is blanked (e.g. cloze render fell back).
+function revealCloze() {
+  if (!clozeActive() || !state.current) return;
+  const expected = state.current.word.inflections[state.current.key];
+  for (const blank of el.clozeFi.querySelectorAll(".cloze-blank")) {
+    blank.textContent = expected;
+    blank.classList.add("filled");
+  }
+}
+
 function appendHighlighted(parent, text, re) {
   if (!re) { parent.textContent = text; return; }
   let lastIdx = 0;
@@ -310,10 +390,14 @@ function setStatus(text) { el.statusLine.textContent = text; }
 
 function updateStatus() {
   const count = state.pool.length;
-  setStatus(
-    `${state.mode} mode \u2022 ${count.toLocaleString()} possible challenges` +
-    (count === 0 ? " \u2014 all filtered out, enable something above" : "")
-  );
+  const style = clozeActive() ? " cloze" : "";
+  let suffix = "";
+  if (count === 0) {
+    suffix = clozeActive()
+      ? " \u2014 no example sentences match these filters; broaden them or switch to Standard"
+      : " \u2014 all filtered out, enable something above";
+  }
+  setStatus(`${state.mode}${style} mode \u2022 ${count.toLocaleString()} possible challenges${suffix}`);
 }
 
 // ---------- analytics ----------
@@ -797,6 +881,7 @@ function blitzSubmit() {
     // to actually read on mobile.
     const expected = result.expected;
     setFeedback(`\u2717 was: ${expected}`, "bad");
+    revealCloze();
     el.answer.classList.add("blitz-flash-bad");
     buzzIfWrong();
     b.wrongFlashUntil = Date.now() + 800;
@@ -1014,6 +1099,7 @@ function submit() {
   const result = checkAnswer(state.current, input);
   if (result.ok) {
     setFeedback("\u2713 correct", "ok");
+    revealCloze();
     score(state.hintsShown > 0 ? "wrong" : "correct");
     state.awaitingNext = true;
     // Advance after the TTS finishes, not on a fixed timer. Finnish words
@@ -1038,6 +1124,7 @@ function submit() {
     score("wrong");
     buzzIfWrong();
     setFeedback(`\u2717 expected: ${result.expected}`, "bad");
+    revealCloze();
     maybeAutoPlayAnswer();
     state.awaitingNext = true;
   }
@@ -1076,6 +1163,7 @@ function revealNextLetter() {
     }
     score("wrong");
     setFeedback(`✗ ${expected}`, "bad");
+    revealCloze();
     maybeAutoPlayAnswer();
     state.awaitingNext = true;
   } else {
@@ -1096,6 +1184,7 @@ function showFullAnswer() {
   const expected = state.current.word.inflections[state.current.key];
   el.answer.value = expected;
   setFeedback(`answer shown: ${expected}`, "bad");
+  revealCloze();
   score("shown");
   maybeAutoPlayAnswer();
   state.awaitingNext = true;
@@ -1142,6 +1231,10 @@ function rebuildPool(opts) {
     });
   }
 
+  // Cloze style: keep only challenges whose word has an example sentence
+  // containing the target form, and remember which example it was.
+  if (clozeActive()) pool = buildClozePool(pool);
+
   state.pool = pool;
   updateStatus();
   newChallenge(opts);
@@ -1168,6 +1261,7 @@ function setView(view) {
   // to drill (otherwise the "hidden" class from newChallenge wins).
   el.challenge.classList.toggle("hidden", !(drill && state.current));
   el.answerRow.classList.toggle("hidden", !(drill && state.current));
+  el.drillStyleRow.classList.toggle("hidden", !drill);
   el.filtersNoun.classList.toggle("hidden", !(drill && state.mode === "noun"));
   el.filtersVerb.classList.toggle("hidden", !(drill && state.mode === "verb"));
   // Presets live between filters and test mode; drill-only, and the list is
@@ -1212,6 +1306,192 @@ function setMode(mode) {
   // prompt when you click the tab you're already on.
   if (changed || !state.current) rebuildPool();
   else updateStatus();
+}
+
+// ---------- drill style (standard / cloze) ----------
+function renderDrillStyleSwitch() {
+  if (!el.drillStyleSwitch) return;
+  const pref = (state.settings && state.settings.drillStyle) || "standard";
+  for (const btn of el.drillStyleSwitch.querySelectorAll(".seg-btn")) {
+    const active = btn.dataset.value === pref;
+    btn.classList.toggle("active", active);
+    btn.setAttribute("aria-checked", active ? "true" : "false");
+  }
+}
+
+function updateAnswerPlaceholder() {
+  el.answer.placeholder = clozeActive()
+    ? "type the missing form and press Enter"
+    : "type the form and press Enter";
+}
+
+function setDrillStyle(style) {
+  if (style !== "standard" && style !== "cloze") return;
+  if (state.settings.drillStyle === style) return;
+  // The cloze pool is a different challenge set, so switching style mid-test
+  // or mid-blitz invalidates the run — same confirm flow as a mode switch.
+  if (testActive()) {
+    if (!confirm("Switching drill style will cancel the current test. Continue?")) return;
+    cancelTest();
+  }
+  if (blitzActive()) {
+    if (!confirm("Switching drill style will cancel the current Blitz round. Continue?")) return;
+    cancelBlitz();
+  }
+  state.settings.drillStyle = style;
+  saveSettings(state.settings);
+  renderDrillStyleSwitch();
+  updateAnswerPlaceholder();
+  track("drill_style", { style });
+  rebuildPool();
+}
+
+// ---------- full inflection table ----------
+// Opened by tapping the headword. While the current challenge is unanswered,
+// every cell whose value matches the expected answer is masked, so the table
+// works as a paradigm reference without doubling as a free "show answer".
+
+function openInflectionTable() {
+  if (!state.current) return;
+  // A reference aid has no place inside timed or unaided runs — the hint
+  // buttons at least carry a stats penalty; this wouldn't.
+  if (blitzActive() || testActive()) return;
+  const { word, key } = state.current;
+  const expected = word.inflections[key];
+  const concealed = !(state.awaitingNext || state.scoredThisChallenge);
+  el.inflectionTitle.textContent = word.word;
+  el.inflectionNote.classList.toggle("hidden", !concealed);
+  el.inflectionBody.innerHTML = "";
+  if (state.mode === "noun") {
+    el.inflectionBody.appendChild(buildNounTable(word, key, expected, concealed));
+  } else {
+    buildVerbTables(el.inflectionBody, word, key, expected, concealed);
+  }
+  track("inflection_table_open", { mode: state.mode });
+  el.inflectionModal.classList.remove("hidden");
+}
+
+function closeInflectionTable() {
+  el.inflectionModal.classList.add("hidden");
+  if (state.view === "drill") el.answer.focus();
+}
+
+function inflectionCell(value, key, currentKey, expected, concealed) {
+  const td = document.createElement("td");
+  if (!value) {
+    td.textContent = "—";
+    td.className = "infl-empty";
+    return td;
+  }
+  if (key === currentKey) td.classList.add("infl-target");
+  if (concealed && value === expected) {
+    td.classList.add("infl-masked");
+    td.textContent = "•••";
+    td.title = "hidden until you answer";
+  } else {
+    td.textContent = value;
+  }
+  return td;
+}
+
+function inflectionTableSkeleton(headers) {
+  const table = document.createElement("table");
+  table.className = "infl-table";
+  const thead = document.createElement("thead");
+  const tr = document.createElement("tr");
+  for (const h of headers) {
+    const th = document.createElement("th");
+    th.textContent = h;
+    tr.appendChild(th);
+  }
+  thead.appendChild(tr);
+  table.appendChild(thead);
+  const tbody = document.createElement("tbody");
+  table.appendChild(tbody);
+  return { table, tbody };
+}
+
+function buildNounTable(word, currentKey, expected, concealed) {
+  const { table, tbody } = inflectionTableSkeleton(["", "Singular", "Plural"]);
+  for (const c of state.cfg.nounCases.cases) {
+    const sg = word.inflections[`${c.id}_singular`];
+    const pl = word.inflections[`${c.id}_plural`];
+    if (!sg && !pl) continue;
+    const tr = document.createElement("tr");
+    const th = document.createElement("th");
+    th.scope = "row";
+    th.textContent = c.label;
+    tr.appendChild(th);
+    tr.appendChild(inflectionCell(sg, `${c.id}_singular`, currentKey, expected, concealed));
+    tr.appendChild(inflectionCell(pl, `${c.id}_plural`, currentKey, expected, concealed));
+    tbody.appendChild(tr);
+  }
+  return table;
+}
+
+// Conventional Finnish conjugation layout: one table per tense/mood with
+// pronoun rows + a passive row, positive and negative columns. Participles
+// and infinitives don't fit that grid, so they land in a flat list at the end.
+const VERB_TABLE_PRONOUNS = {
+  "1sg": "minä", "2sg": "sinä", "3sg": "hän",
+  "1pl": "me",   "2pl": "te",   "3pl": "he",
+  passive: "passive",
+};
+
+function buildVerbTables(container, word, currentKey, expected, concealed) {
+  const byTense = new Map(); // tenseId → { rowId → { positive: key, negative: key } }
+  const nonFinite = [];
+  for (const k of Object.keys(word.inflections || {})) {
+    const p = parseVerbKey(k);
+    if (p.kind !== "finite") { nonFinite.push(k); continue; }
+    let rows = byTense.get(p.tense);
+    if (!rows) { rows = {}; byTense.set(p.tense, rows); }
+    const rowId = p.person || "passive"; // passive forms carry no person
+    const slot = rows[rowId] || (rows[rowId] = {});
+    slot[p.polarity] = k;
+  }
+
+  const rowOrder = [...state.cfg.verbForms.persons.map((p) => p.id), "passive"];
+  for (const tense of state.cfg.verbForms.tenses) {
+    const rows = byTense.get(tense.id);
+    if (!rows) continue;
+    const h = document.createElement("h3");
+    h.textContent = tense.label;
+    container.appendChild(h);
+    const { table, tbody } = inflectionTableSkeleton(["", "Positive", "Negative"]);
+    for (const rowId of rowOrder) {
+      const slot = rows[rowId];
+      if (!slot) continue;
+      const tr = document.createElement("tr");
+      const th = document.createElement("th");
+      th.scope = "row";
+      th.textContent = VERB_TABLE_PRONOUNS[rowId] || rowId;
+      tr.appendChild(th);
+      tr.appendChild(inflectionCell(
+        word.inflections[slot.positive], slot.positive, currentKey, expected, concealed));
+      tr.appendChild(inflectionCell(
+        word.inflections[slot.negative], slot.negative, currentKey, expected, concealed));
+      tbody.appendChild(tr);
+    }
+    container.appendChild(table);
+  }
+
+  if (nonFinite.length > 0) {
+    const h = document.createElement("h3");
+    h.textContent = "participles & infinitives";
+    container.appendChild(h);
+    const { table, tbody } = inflectionTableSkeleton(["", "Form"]);
+    for (const k of nonFinite) {
+      const tr = document.createElement("tr");
+      const th = document.createElement("th");
+      th.scope = "row";
+      th.textContent = verbLabel(k, state.cfg);
+      tr.appendChild(th);
+      tr.appendChild(inflectionCell(word.inflections[k], k, currentKey, expected, concealed));
+      tbody.appendChild(tr);
+    }
+    container.appendChild(table);
+  }
 }
 
 // ---------- presets ----------
@@ -1555,6 +1835,22 @@ async function boot() {
     el.hintAnswer.addEventListener("click", showFullAnswer);
     el.skip.addEventListener("click", skipChallenge);
 
+    // Drill style: Standard / Cloze segmented control above the challenge.
+    renderDrillStyleSwitch();
+    updateAnswerPlaceholder();
+    el.drillStyleSwitch.addEventListener("click", (e) => {
+      const btn = e.target.closest(".seg-btn");
+      if (!btn) return;
+      setDrillStyle(btn.dataset.value);
+    });
+
+    // Full inflection table — opened by tapping the headword.
+    el.headword.addEventListener("click", openInflectionTable);
+    el.inflectionClose.addEventListener("click", closeInflectionTable);
+    el.inflectionModal.addEventListener("click", (e) => {
+      if (e.target === el.inflectionModal) closeInflectionTable();
+    });
+
     // Blitz: launch button + duration picker + start/cancel + result actions.
     el.blitzOpen.addEventListener("click", openBlitzModal);
     el.blitzDurationPicker.addEventListener("click", (e) => {
@@ -1585,7 +1881,9 @@ async function boot() {
     // want the picker to steal focus from there.
     document.addEventListener("keydown", (e) => {
       if (e.key !== "Escape") return;
-      if (!el.blitzStartModal.classList.contains("hidden")) {
+      if (!el.inflectionModal.classList.contains("hidden")) {
+        closeInflectionTable();
+      } else if (!el.blitzStartModal.classList.contains("hidden")) {
         closeBlitzStartModal();
       } else if (!el.testStartModal.classList.contains("hidden")) {
         closeTestStartModal();
@@ -1706,6 +2004,8 @@ async function importStats(file) {
       updateSrsControlsVisibility();
       applyTheme(state.settings.theme);
       renderThemeSwitch();
+      renderDrillStyleSwitch();
+      updateAnswerPlaceholder();
     }
     if (data.schedule && data.schedule.byItem) {
       state.schedule = { byItem: data.schedule.byItem };

--- a/js/settings.js
+++ b/js/settings.js
@@ -25,6 +25,10 @@ export function defaultSettings() {
                               // best rank is <= this value. Matches the cutoff
                               // used by scripts/extract.py at build time.
     theme:             "system", // "system" | "light" | "dark"
+    // Challenge presentation. "standard" shows lemma + grammatical prompt;
+    // "cloze" shows an example sentence with the target form blanked out.
+    // Cloze restricts the pool to challenges that have a usable example.
+    drillStyle:        "standard",
     // Gamification is opt-in for new users. Existing users with a stored
     // settings blob keep streak visibility via the migration below, so this
     // default only applies to fresh installs.

--- a/js/version.js
+++ b/js/version.js
@@ -3,5 +3,5 @@
 // Convention (post-1.0): semver-ish. Patch bump (1.0.x) for bug fixes only,
 // minor bump (1.x.0) for new features, major bump (x.0.0) for breaking
 // changes. Remember to also update CACHE_VERSION in sw.js to match.
-// Skipping 0.13 / 1.3 — superstition trumps monotonic numbering.
-export const APP_VERSION = "1.2.0";
+// (0.13 was skipped out of superstition; 1.3 ships anyway — owner's call.)
+export const APP_VERSION = "1.3.0";

--- a/sw.js
+++ b/sw.js
@@ -10,7 +10,7 @@
 // ⚠️ BUMP `CACHE_VERSION` whenever you ship app-shell changes that users need
 //    to pick up. Without a bump, they'll keep the old cached files forever.
 
-const CACHE_VERSION = "finnish-drill-v1.2.0";
+const CACHE_VERSION = "finnish-drill-v1.3.0";
 
 // Files required for the app to boot offline. Paths are relative so this
 // works under any base path (e.g. GitHub Pages project site).


### PR DESCRIPTION
## Summary

- **Cloze drill mode**: a new "Cloze" style switch above the challenge card builds a sub-pool of challenges where an example sentence exists for the target form. The sentence is shown with the target form blanked out; correct answer fills it in. Deduplicates on identical surface forms per sentence.
- **Full inflection table**: the headword is now a tappable button. Clicking it opens a modal showing the complete inflection table — noun case×number grid or per-tense pronoun grids for verbs, plus a non-finite section. Cells matching the current unanswered challenge are masked (•••) until the user has answered.
- Version bump to 1.3.0; service-worker cache key updated to evict stale files on deploy.

## Test plan

- [ ] Standard drill still works for nouns and verbs
- [ ] Cloze switch appears in drill view; switching rebuilds pool and updates placeholder text
- [ ] Cloze challenges show a sentence with a blank; correct answer fills it
- [ ] Empty cloze pool shows descriptive status message
- [ ] Tapping headword opens inflection modal; current answer cell is masked; after answering it reveals
- [ ] Inflection modal closes on Close button, backdrop click, and Esc
- [ ] Modal does not open during blitz or test mode
- [ ] Service worker update banner fires after deploy (cache version changed)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5suKu1Emw3x3V4x5JTcSf)_