### PR TITLE
Verb Rection drill + (beta) tags on Cloze & Rection — v1.4.1

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -316,11 +316,68 @@ button.headword:hover { border-bottom-color: var(--accent); }
   margin-top: 0.5rem;
 }
 
-/* Drill style switch (Standard / Cloze) — slim centered row above the card. */
+/* Drill style switch (Standard / Cloze / Rection) — slim centered row above
+ * the card. The Rection button itself is hidden outside verb mode (JS). */
 .drill-style-row {
   display: flex;
   justify-content: center;
   margin-bottom: 0.75rem;
+}
+
+/* Rection drill style: the answer is one of four multiple-choice complement
+ * buttons, so the typed-answer chrome (input + letter hints + speak + the
+ * test/blitz launchers, which don't support this style) collapses away.
+ * Skip stays — it's the only hint-row action that still applies. */
+body.rection-mode .answer-wrap,
+body.rection-mode #hint-letter,
+body.rection-mode #hint-answer,
+body.rection-mode #speak-answer,
+body.rection-mode #test-open,
+body.rection-mode #blitz-open { display: none; }
+
+.rection-choices {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem;
+  margin-bottom: 0.65rem;
+}
+.rection-choice {
+  background: var(--panel-2);
+  color: var(--text-dim);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0.6rem 0.8rem;
+  cursor: pointer;
+  font-size: 0.92rem;
+  font-family: inherit;
+  text-align: left;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  transition: color var(--dur) var(--ease), border-color var(--dur) var(--ease),
+              background var(--dur) var(--ease), transform 80ms var(--ease);
+}
+.rection-choice:hover:not(:disabled) {
+  color: var(--text);
+  border-color: var(--border-strong);
+  background: var(--panel-hover);
+}
+.rection-choice:active:not(:disabled) { transform: translateY(1px); }
+.rection-choice:disabled { cursor: default; opacity: 0.55; }
+.rection-choice.correct {
+  border-color: var(--ok);
+  background: var(--ok-soft);
+  color: var(--text);
+  opacity: 1;
+}
+.rection-choice.wrong {
+  border-color: var(--danger);
+  background: var(--danger-soft);
+  color: var(--text);
+  opacity: 1;
+}
+@media (max-width: 480px) {
+  .rection-choices { grid-template-columns: 1fr; }
 }
 
 /* Speaker button — inline with the headword. */

--- a/css/style.css
+++ b/css/style.css
@@ -1112,6 +1112,7 @@ kbd {
 }
 .seg-btn:hover  { color: var(--text); }
 .seg-btn:active { transform: scale(0.96); }
+.beta-tag { font-size: 0.7em; opacity: 0.65; }
 .seg-btn.active {
   background: linear-gradient(180deg, var(--accent), var(--accent-soft));
   color: var(--on-accent);

--- a/data/rection.json
+++ b/data/rection.json
@@ -1,0 +1,1829 @@
+{
+ "_source": "Rection annotations from English Wiktionary Finnish verb glosses (en.wiktionary.org, via the kaikki.org extract), CC BY-SA 4.0. Parsed by scripts/extract_rection.py from data/verbs.json.",
+ "complements": [
+  "ablative",
+  "accusative",
+  "adessive",
+  "allative",
+  "elative",
+  "essive",
+  "illative",
+  "inessive",
+  "inf1",
+  "inf2_inessive",
+  "inf3_elative",
+  "inf3_illative",
+  "inf3_inessive",
+  "partitive",
+  "translative"
+ ],
+ "words": [
+  {
+   "word": "pitää",
+   "frequency_rank": 53,
+   "items": [
+    {
+     "key": "rection:partitive",
+     "glosses": [
+      "to hold (have and keep possession of something)"
+     ],
+     "hint": null,
+     "accept": [
+      "partitive"
+     ]
+    },
+    {
+     "key": "rection:elative:onto",
+     "glosses": [
+      "to hold (have and keep possession of something)"
+     ],
+     "hint": "onto",
+     "accept": [
+      "elative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "tietää",
+   "frequency_rank": 59,
+   "items": [
+    {
+     "key": "rection:elative:about",
+     "glosses": [
+      "to know, be aware of (in some cases implying superficial knowledge, see the usage notes below)"
+     ],
+     "hint": "about",
+     "accept": [
+      "elative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "saada",
+   "frequency_rank": 85,
+   "items": [
+    {
+     "key": "rection:elative:out-of",
+     "glosses": [
+      "to get, make, produce, yield"
+     ],
+     "hint": "out of",
+     "accept": [
+      "elative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "tulla",
+   "frequency_rank": 86,
+   "items": [
+    {
+     "key": "rection:translative",
+     "glosses": [
+      "to become, get, go, turn (usually an adjective or a participle, only rarely a noun)"
+     ],
+     "hint": null,
+     "accept": [
+      "translative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "nähdä",
+   "frequency_rank": 108,
+   "items": [
+    {
+     "key": "rection:inf1:to-do",
+     "glosses": [
+      "can see (have enough vision to be able to do something)"
+     ],
+     "hint": "to do",
+     "accept": [
+      "inf1"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "mennä",
+   "frequency_rank": 119,
+   "items": [
+    {
+     "key": "rection:inf3_illative:to-do",
+     "glosses": [
+      "to go (move away from a point of reference)"
+     ],
+     "hint": "to do",
+     "accept": [
+      "inf3_illative"
+     ]
+    },
+    {
+     "key": "rection:illative+translative",
+     "glosses": [
+      "to go, enter, get, begin, start (general verb for describing entering some kind of state)"
+     ],
+     "hint": null,
+     "accept": [
+      "illative",
+      "translative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "sanoa",
+   "frequency_rank": 157,
+   "items": [
+    {
+     "key": "rection:translative",
+     "glosses": [
+      "to call, name, dub; (passive) go by"
+     ],
+     "hint": null,
+     "accept": [
+      "translative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "päästää",
+   "frequency_rank": 171,
+   "items": [
+    {
+     "key": "rection:allative+illative",
+     "glosses": [
+      "to let (free someone of some restraint, obligation, etc. that prevents them from doing something or going somewhere)"
+     ],
+     "hint": null,
+     "accept": [
+      "illative",
+      "allative"
+     ]
+    },
+    {
+     "key": "rection:inf3_illative:to-do",
+     "glosses": [
+      "to let (free someone of some restraint, obligation, etc. that prevents them from doing something or going somewhere)"
+     ],
+     "hint": "to do",
+     "accept": [
+      "inf3_illative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "päästä",
+   "frequency_rank": 171,
+   "items": [
+    {
+     "key": "rection:allative+illative",
+     "glosses": [
+      "to get to, reach, arrive at/in (a place)"
+     ],
+     "hint": null,
+     "accept": [
+      "illative",
+      "allative"
+     ]
+    },
+    {
+     "key": "rection:inf3_illative:to-do",
+     "glosses": [
+      "to get to, reach, arrive at/in (a place)"
+     ],
+     "hint": "to do",
+     "accept": [
+      "inf3_illative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "puhua",
+   "frequency_rank": 172,
+   "items": [
+    {
+     "key": "rection:elative:about-of",
+     "glosses": [
+      "to speak, talk (communicate, discuss, converse; usually by speaking or with one's voice)"
+     ],
+     "hint": "about, of",
+     "accept": [
+      "elative"
+     ]
+    },
+    {
+     "key": "rection:allative:to",
+     "glosses": [
+      "to speak, talk (communicate, discuss, converse; usually by speaking or with one's voice)"
+     ],
+     "hint": "to",
+     "accept": [
+      "allative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "näyttää",
+   "frequency_rank": 186,
+   "items": [
+    {
+     "key": "rection:ablative+allative",
+     "glosses": [
+      "to look like, resemble (to be similar in appearance to)"
+     ],
+     "hint": null,
+     "accept": [
+      "ablative",
+      "allative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "vastata",
+   "frequency_rank": 226,
+   "items": [
+    {
+     "key": "rection:adessive:with",
+     "glosses": [
+      "to react, counter, respond, reciprocate (to take action in response to)"
+     ],
+     "hint": "with",
+     "accept": [
+      "adessive"
+     ]
+    },
+    {
+     "key": "rection:illative:to",
+     "glosses": [
+      "to react, counter, respond, reciprocate (to take action in response to)"
+     ],
+     "hint": "to",
+     "accept": [
+      "illative"
+     ]
+    },
+    {
+     "key": "rection:allative",
+     "glosses": [
+      "to account to (to be accountable or responsible to)"
+     ],
+     "hint": null,
+     "accept": [
+      "allative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "uskoa",
+   "frequency_rank": 228,
+   "items": [
+    {
+     "key": "rection:illative:in",
+     "glosses": [
+      "to believe, have faith"
+     ],
+     "hint": "in",
+     "accept": [
+      "illative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "lähteä",
+   "frequency_rank": 268,
+   "items": [
+    {
+     "key": "rection:inf3_illative",
+     "glosses": [
+      "to begin, start, start out, start off (often with more contrast than mennä, alkaa, ryhtyä etc.)"
+     ],
+     "hint": null,
+     "accept": [
+      "inf3_illative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "lisätä",
+   "frequency_rank": 297,
+   "items": [
+    {
+     "key": "rection:illative:in-to",
+     "glosses": [
+      "to add (make an addition, augment, increase; say further information, add on)"
+     ],
+     "hint": "in/to",
+     "accept": [
+      "illative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "kuulua",
+   "frequency_rank": 343,
+   "items": [
+    {
+     "key": "rection:allative:to",
+     "glosses": [
+      "to belong (showing ownership or location)"
+     ],
+     "hint": "to",
+     "accept": [
+      "allative"
+     ]
+    },
+    {
+     "key": "rection:illative:to",
+     "glosses": [
+      "to belong (to be member of)"
+     ],
+     "hint": "to",
+     "accept": [
+      "illative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "kuulostaa",
+   "frequency_rank": 417,
+   "items": [
+    {
+     "key": "rection:ablative+allative",
+     "glosses": [
+      "to sound (convey an impression by one's sound)"
+     ],
+     "hint": null,
+     "accept": [
+      "ablative",
+      "allative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "kuulla",
+   "frequency_rank": 444,
+   "items": [
+    {
+     "key": "rection:elative",
+     "glosses": [
+      "to hear of (to become aware of something through second-hand knowledge)"
+     ],
+     "hint": null,
+     "accept": [
+      "elative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "pystyä",
+   "frequency_rank": 476,
+   "items": [
+    {
+     "key": "rection:illative",
+     "glosses": [
+      "to (be able to) cut into, (be able to) sink into, to bite into (of an axe, knife, etc.)"
+     ],
+     "hint": null,
+     "accept": [
+      "illative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "jäädä",
+   "frequency_rank": 534,
+   "items": [
+    {
+     "key": "rection:translative",
+     "glosses": [
+      "to end up (as), to become (of negative or neutral states)"
+     ],
+     "hint": null,
+     "accept": [
+      "translative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "sopia",
+   "frequency_rank": 573,
+   "items": [
+    {
+     "key": "rection:allative",
+     "glosses": [
+      "to fit (to be of the correct size and shape; to be capable of being put into or passing through something; to be not too big)"
+     ],
+     "hint": null,
+     "accept": [
+      "allative"
+     ]
+    },
+    {
+     "key": "rection:illative",
+     "glosses": [
+      "to comport with, match (to be in agreement with; to be of an accord)"
+     ],
+     "hint": null,
+     "accept": [
+      "illative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "syyttää",
+   "frequency_rank": 629,
+   "items": [
+    {
+     "key": "rection:elative:for",
+     "glosses": [
+      "to blame, blame (something) on, accuse"
+     ],
+     "hint": "for",
+     "accept": [
+      "elative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "taitaa",
+   "frequency_rank": 662,
+   "items": [
+    {
+     "key": "rection:inf1",
+     "glosses": [
+      "to probably do, think that one does (active past participle: tainnut or taitanut)"
+     ],
+     "hint": null,
+     "accept": [
+      "inf1"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "vaikuttaa",
+   "frequency_rank": 739,
+   "items": [
+    {
+     "key": "rection:essive",
+     "glosses": [
+      "to act as, to work as, to do (to have as one's job)"
+     ],
+     "hint": null,
+     "accept": [
+      "essive"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "istua",
+   "frequency_rank": 744,
+   "items": [
+    {
+     "key": "rection:allative",
+     "glosses": [
+      "to suit, fit (e.g. of clothing)"
+     ],
+     "hint": null,
+     "accept": [
+      "allative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "mahtaa",
+   "frequency_rank": 815,
+   "items": [
+    {
+     "key": "rection:inf1",
+     "glosses": [
+      "one supposes, probably do, must do (in suppositions)"
+     ],
+     "hint": null,
+     "accept": [
+      "inf1"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "sattua",
+   "frequency_rank": 981,
+   "items": [
+    {
+     "key": "rection:inf3_illative:to-do",
+     "glosses": [
+      "to happen (do or occur by chance or unexpectedly)"
+     ],
+     "hint": "to do",
+     "accept": [
+      "inf3_illative"
+     ]
+    },
+    {
+     "key": "rection:illative",
+     "glosses": [
+      "to touch (to come involuntarily into contact with)"
+     ],
+     "hint": null,
+     "accept": [
+      "illative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "panna",
+   "frequency_rank": 1077,
+   "items": [
+    {
+     "key": "rection:inf3_illative:to",
+     "glosses": [
+      "to send (make someone go somewhere)"
+     ],
+     "hint": "to",
+     "accept": [
+      "inf3_illative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "haista",
+   "frequency_rank": 1161,
+   "items": [
+    {
+     "key": "rection:ablative+allative",
+     "glosses": [
+      "to smell, to have a smell/scent/odor; to stink"
+     ],
+     "hint": null,
+     "accept": [
+      "ablative",
+      "allative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "valita",
+   "frequency_rank": 1193,
+   "items": [
+    {
+     "key": "rection:translative:as-into-the-position-of",
+     "glosses": [
+      "to elect, choose (into a position of power)"
+     ],
+     "hint": "as, into the position of",
+     "accept": [
+      "translative"
+     ]
+    },
+    {
+     "key": "rection:inf3_illative:to-do",
+     "glosses": [
+      "to elect, choose (into a position of power)"
+     ],
+     "hint": "to do",
+     "accept": [
+      "inf3_illative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "valittaa",
+   "frequency_rank": 1193,
+   "items": [
+    {
+     "key": "rection:elative:about",
+     "glosses": [
+      "to complain, grouse, gripe, whine, bemoan, lament (orally or in writing)"
+     ],
+     "hint": "about",
+     "accept": [
+      "elative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "koskea",
+   "frequency_rank": 1236,
+   "items": [
+    {
+     "key": "rection:illative",
+     "glosses": [
+      "to touch (physically disturb; to interfere with, molest, or attempt to harm through contact)"
+     ],
+     "hint": null,
+     "accept": [
+      "illative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "kiittää",
+   "frequency_rank": 1310,
+   "items": [
+    {
+     "key": "rection:elative:for",
+     "glosses": [
+      "to thank, express one's gratitude"
+     ],
+     "hint": "for",
+     "accept": [
+      "elative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "vaihtaa",
+   "frequency_rank": 1443,
+   "items": [
+    {
+     "key": "rection:illative+translative:for",
+     "glosses": [
+      "to trade (give in exchange for)"
+     ],
+     "hint": "for",
+     "accept": [
+      "illative",
+      "translative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "joutua",
+   "frequency_rank": 1472,
+   "items": [
+    {
+     "key": "rection:illative",
+     "glosses": [
+      "to get (into a negative position or situation)"
+     ],
+     "hint": null,
+     "accept": [
+      "illative"
+     ]
+    },
+    {
+     "key": "rection:allative+illative:in",
+     "glosses": [
+      "to end up (involuntarily, in a place considered negative)"
+     ],
+     "hint": "in",
+     "accept": [
+      "illative",
+      "allative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "jaksaa",
+   "frequency_rank": 1627,
+   "items": [
+    {
+     "key": "rection:inf1:to-do",
+     "glosses": [
+      "to manage, to have enough strength"
+     ],
+     "hint": "to do",
+     "accept": [
+      "inf1"
+     ]
+    },
+    {
+     "key": "rection:accusative:for-with",
+     "glosses": [
+      "to manage, to have enough strength"
+     ],
+     "hint": "for/with",
+     "accept": [
+      "accusative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "puuttua",
+   "frequency_rank": 1838,
+   "items": [
+    {
+     "key": "rection:ablative+elative:from",
+     "glosses": [
+      "to be missing; to be lacking; (elative/ablative +) to lack"
+     ],
+     "hint": "from",
+     "accept": [
+      "elative",
+      "ablative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "suostua",
+   "frequency_rank": 1858,
+   "items": [
+    {
+     "key": "rection:illative",
+     "glosses": [
+      "to accept, approve (a request, an application, etc.)"
+     ],
+     "hint": null,
+     "accept": [
+      "illative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "rakastua",
+   "frequency_rank": 1885,
+   "items": [
+    {
+     "key": "rection:illative:with",
+     "glosses": [
+      "to fall in love, enamor"
+     ],
+     "hint": "with",
+     "accept": [
+      "illative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "muistuttaa",
+   "frequency_rank": 1900,
+   "items": [
+    {
+     "key": "rection:elative:of",
+     "glosses": [
+      "to remind (draw attention to an obligation)"
+     ],
+     "hint": "of",
+     "accept": [
+      "elative"
+     ]
+    },
+    {
+     "key": "rection:inf3_illative:to-do",
+     "glosses": [
+      "to remind (draw attention to an obligation)"
+     ],
+     "hint": "to do",
+     "accept": [
+      "inf3_illative"
+     ]
+    },
+    {
+     "key": "rection:allative:to",
+     "glosses": [
+      "to remark (to state something as an observation)"
+     ],
+     "hint": "to",
+     "accept": [
+      "allative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "valehdella",
+   "frequency_rank": 2283,
+   "items": [
+    {
+     "key": "rection:allative:to",
+     "glosses": [
+      "to lie (tell untruths)"
+     ],
+     "hint": "to",
+     "accept": [
+      "allative"
+     ]
+    },
+    {
+     "key": "rection:elative:about",
+     "glosses": [
+      "to lie (tell untruths)"
+     ],
+     "hint": "about",
+     "accept": [
+      "elative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "välttää",
+   "frequency_rank": 2356,
+   "items": [
+    {
+     "key": "rection:inf3_elative:from-doing",
+     "glosses": [
+      "to refrain, make a point (of not doing)"
+     ],
+     "hint": "from doing",
+     "accept": [
+      "inf3_elative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "osua",
+   "frequency_rank": 2368,
+   "items": [
+    {
+     "key": "rection:illative",
+     "glosses": [
+      "to hit, strike, get (a spot, target)"
+     ],
+     "hint": null,
+     "accept": [
+      "illative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "kokea",
+   "frequency_rank": 2530,
+   "items": [
+    {
+     "key": "rection:essive+translative:as",
+     "glosses": [
+      "to see, regard, view, consider"
+     ],
+     "hint": "as",
+     "accept": [
+      "translative",
+      "essive"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "erottaa",
+   "frequency_rank": 2531,
+   "items": [
+    {
+     "key": "rection:elative:from",
+     "glosses": [
+      "to fire, dismiss (to relieve of a duty)",
+      "to expel (to terminate the membership of)"
+     ],
+     "hint": "from",
+     "accept": [
+      "elative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "yltää",
+   "frequency_rank": 2927,
+   "items": [
+    {
+     "key": "rection:allative+illative",
+     "glosses": [
+      "to (be able to) reach (usually with one's limbs)"
+     ],
+     "hint": null,
+     "accept": [
+      "illative",
+      "allative"
+     ]
+    },
+    {
+     "key": "rection:inf3_illative:to-do",
+     "glosses": [
+      "to (be able to) reach (usually with one's limbs)"
+     ],
+     "hint": "to do",
+     "accept": [
+      "inf3_illative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "nauttia",
+   "frequency_rank": 2934,
+   "items": [
+    {
+     "key": "rection:elative",
+     "glosses": [
+      "to enjoy (receive enjoyment from)",
+      "to enjoy, use (a legal right)"
+     ],
+     "hint": null,
+     "accept": [
+      "elative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "maistua",
+   "frequency_rank": 3125,
+   "items": [
+    {
+     "key": "rection:allative:to",
+     "glosses": [
+      "to taste good, taste appealing, suit someone's appetite",
+      "to be appealing, be to someone's liking"
+     ],
+     "hint": "to",
+     "accept": [
+      "allative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "erota",
+   "frequency_rank": 3154,
+   "items": [
+    {
+     "key": "rection:elative",
+     "glosses": [
+      "to resign, quit (quit a job or position)",
+      "to divorce (dissolve a marriage)"
+     ],
+     "hint": null,
+     "accept": [
+      "elative"
+     ]
+    },
+    {
+     "key": "rection:elative:with",
+     "glosses": [
+      "to break up (end a relationship)"
+     ],
+     "hint": "with",
+     "accept": [
+      "elative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "iskeä",
+   "frequency_rank": 3210,
+   "items": [
+    {
+     "key": "rection:illative:on",
+     "glosses": [
+      "to crack down (to enforce more stringently or more thoroughly)"
+     ],
+     "hint": "on",
+     "accept": [
+      "illative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "yllättyä",
+   "frequency_rank": 3281,
+   "items": [
+    {
+     "key": "rection:elative+illative",
+     "glosses": [
+      "to be surprised (by) (become surprised by something)"
+     ],
+     "hint": null,
+     "accept": [
+      "elative",
+      "illative"
+     ]
+    },
+    {
+     "key": "rection:inf2_inessive:to-do",
+     "glosses": [
+      "to be surprised (by) (become surprised by something)"
+     ],
+     "hint": "to do",
+     "accept": [
+      "inf2_inessive"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "ehdottaa",
+   "frequency_rank": 3421,
+   "items": [
+    {
+     "key": "rection:translative",
+     "glosses": [
+      "to nominate, propose (put someone forward as a candidate)"
+     ],
+     "hint": null,
+     "accept": [
+      "translative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "määrätä",
+   "frequency_rank": 3496,
+   "items": [
+    {
+     "key": "rection:inf3_illative:to-do",
+     "glosses": [
+      "to order, command, instruct, tell, enjoin (order someone to do something)"
+     ],
+     "hint": "to do",
+     "accept": [
+      "inf3_illative"
+     ]
+    },
+    {
+     "key": "rection:translative:as",
+     "glosses": [
+      "to assign, ordain (to a position)"
+     ],
+     "hint": "as",
+     "accept": [
+      "translative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "turvata",
+   "frequency_rank": 3606,
+   "items": [
+    {
+     "key": "rection:illative",
+     "glosses": [
+      "to depend on, rely on, count on (e.g. God)"
+     ],
+     "hint": null,
+     "accept": [
+      "illative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "palkata",
+   "frequency_rank": 3707,
+   "items": [
+    {
+     "key": "rection:translative:as-into-the-position-of",
+     "glosses": [
+      "to hire, employ, recruit (provide someone with a (new) job)"
+     ],
+     "hint": "as, into the position of",
+     "accept": [
+      "translative"
+     ]
+    },
+    {
+     "key": "rection:inf3_illative:to-do",
+     "glosses": [
+      "to hire, employ, recruit (provide someone with a (new) job)"
+     ],
+     "hint": "to do",
+     "accept": [
+      "inf3_illative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "hirvetä",
+   "frequency_rank": 3863,
+   "items": [
+    {
+     "key": "rection:inf1",
+     "glosses": [
+      "to dare ((to) do), venture (to do), have the courage (to do), be brave enough (to do) (usually something very scary or frightening)"
+     ],
+     "hint": null,
+     "accept": [
+      "inf1"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "ryhtyä",
+   "frequency_rank": 4063,
+   "items": [
+    {
+     "key": "rection:translative",
+     "glosses": [
+      "to become (usually a proponent of a profession)"
+     ],
+     "hint": null,
+     "accept": [
+      "translative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "perustua",
+   "frequency_rank": 4079,
+   "items": [
+    {
+     "key": "rection:illative",
+     "glosses": [
+      "to be based on (e.g. of a work of art)",
+      "to be based on, be grounded in (e.g. of an opinion)"
+     ],
+     "hint": null,
+     "accept": [
+      "illative"
+     ]
+    },
+    {
+     "key": "rection:allative+illative",
+     "glosses": [
+      "to be founded on, be based on, rest on (e.g. of some sort of system)"
+     ],
+     "hint": null,
+     "accept": [
+      "allative",
+      "illative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "osallistua",
+   "frequency_rank": 4249,
+   "items": [
+    {
+     "key": "rection:allative",
+     "glosses": [
+      "to attend (e.g. a lecture, a course)"
+     ],
+     "hint": null,
+     "accept": [
+      "allative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "ihastua",
+   "frequency_rank": 4331,
+   "items": [
+    {
+     "key": "rection:illative",
+     "glosses": [
+      "to fall for, become infatuated with, fall in love with (a person or a thing)"
+     ],
+     "hint": null,
+     "accept": [
+      "illative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "neuvoa",
+   "frequency_rank": 4757,
+   "items": [
+    {
+     "key": "rection:inf3_illative:to-do",
+     "glosses": [
+      "to advise, counsel; show (give advice to, offer as advice)",
+      "to show, advise (to advise by showing)"
+     ],
+     "hint": "to do",
+     "accept": [
+      "inf3_illative"
+     ]
+    },
+    {
+     "key": "rection:inessive:with",
+     "glosses": [
+      "to advise, counsel; show (give advice to, offer as advice)"
+     ],
+     "hint": "with",
+     "accept": [
+      "inessive"
+     ]
+    },
+    {
+     "key": "rection:allative:who-is-shown-or-advised",
+     "glosses": [
+      "to show, advise (to advise by showing)"
+     ],
+     "hint": "who is shown or advised",
+     "accept": [
+      "allative"
+     ]
+    },
+    {
+     "key": "rection:allative+illative:to",
+     "glosses": [
+      "to direct, guide, tell (the way/how to get to) (point out to or show the right course or way)"
+     ],
+     "hint": "to",
+     "accept": [
+      "illative",
+      "allative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "toimittaa",
+   "frequency_rank": 5036,
+   "items": [
+    {
+     "key": "rection:allative+illative",
+     "glosses": [
+      "to supply, provide (with), give"
+     ],
+     "hint": null,
+     "accept": [
+      "illative",
+      "allative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "hävetä",
+   "frequency_rank": 5454,
+   "items": [
+    {
+     "key": "rection:inf1:doing",
+     "glosses": [
+      "to be ashamed (of), feel ashamed"
+     ],
+     "hint": "doing",
+     "accept": [
+      "inf1"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "sekaantua",
+   "frequency_rank": 5851,
+   "items": [
+    {
+     "key": "rection:illative:with",
+     "glosses": [
+      "to get involved, interfere"
+     ],
+     "hint": "with",
+     "accept": [
+      "illative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "mahtua",
+   "frequency_rank": 6530,
+   "items": [
+    {
+     "key": "rection:allative+illative:into-onto",
+     "glosses": [
+      "to fit, have enough space (have sufficient space; conform to in size and shape; be of the right size and shape)"
+     ],
+     "hint": "into/onto",
+     "accept": [
+      "illative",
+      "allative"
+     ]
+    },
+    {
+     "key": "rection:inf3_illative:to-do",
+     "glosses": [
+      "to fit, have enough space (have sufficient space; conform to in size and shape; be of the right size and shape)"
+     ],
+     "hint": "to do",
+     "accept": [
+      "inf3_illative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "hävettää",
+   "frequency_rank": 6563,
+   "items": [
+    {
+     "key": "rection:inf1:to-do",
+     "glosses": [
+      "to be ashamed, feel ashamed"
+     ],
+     "hint": "to do",
+     "accept": [
+      "inf1"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "opiskella",
+   "frequency_rank": 6579,
+   "items": [
+    {
+     "key": "rection:translative:to-be",
+     "glosses": [
+      "to study (to pursue studies of, e.g. at a university)"
+     ],
+     "hint": "to be",
+     "accept": [
+      "translative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "laskettaa",
+   "frequency_rank": 7010,
+   "items": [
+    {
+     "key": "rection:adessive:by",
+     "glosses": [
+      "To have (something) calculated, make (someone) calculate (something)"
+     ],
+     "hint": "by",
+     "accept": [
+      "adessive"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "opetella",
+   "frequency_rank": 7065,
+   "items": [
+    {
+     "key": "rection:inf3_illative:to-do-something",
+     "glosses": [
+      "to (gradually) learn, to teach oneself to"
+     ],
+     "hint": "to do something",
+     "accept": [
+      "inf3_illative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "ruveta",
+   "frequency_rank": 7214,
+   "items": [
+    {
+     "key": "rection:allative",
+     "glosses": [
+      "to fuck with ((begin to) interact with a person in an inappropriate way)"
+     ],
+     "hint": null,
+     "accept": [
+      "allative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "ojentaa",
+   "frequency_rank": 7851,
+   "items": [
+    {
+     "key": "rection:allative:to",
+     "glosses": [
+      "to reach, hand out (to give by stretching out)",
+      "to hand, give, reach, pass (to give, pass or transmit with the hand)"
+     ],
+     "hint": "to",
+     "accept": [
+      "allative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "hurrata",
+   "frequency_rank": 7901,
+   "items": [
+    {
+     "key": "rection:allative",
+     "glosses": [
+      "to cheer (applaud or encourage with cheers or shouts)"
+     ],
+     "hint": null,
+     "accept": [
+      "allative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "paljastua",
+   "frequency_rank": 8037,
+   "items": [
+    {
+     "key": "rection:translative:as-to-be",
+     "glosses": [
+      "to become exposed or revealed, turn out, to dawn on, to uncover, to come into daylight, to surface"
+     ],
+     "hint": "as, to be",
+     "accept": [
+      "translative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "myöhästyä",
+   "frequency_rank": 8265,
+   "items": [
+    {
+     "key": "rection:ablative+elative",
+     "glosses": [
+      "to miss (a bus, train, etc.)"
+     ],
+     "hint": null,
+     "accept": [
+      "elative",
+      "ablative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "inhottaa",
+   "frequency_rank": 8727,
+   "items": [
+    {
+     "key": "rection:inf1:to-do",
+     "glosses": [
+      "to disgust (to cause an intense dislike for something)"
+     ],
+     "hint": "to do",
+     "accept": [
+      "inf1"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "sijoittaa",
+   "frequency_rank": 9554,
+   "items": [
+    {
+     "key": "rection:illative:in",
+     "glosses": [
+      "to set, locate, backdrop (a story into a location or point in time)"
+     ],
+     "hint": "in",
+     "accept": [
+      "illative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "pyrkiä",
+   "frequency_rank": 9826,
+   "items": [
+    {
+     "key": "rection:allative+illative+inf3_illative",
+     "glosses": [
+      "to strive, endeavour, seek to, pursue (to attempt through application of effort)"
+     ],
+     "hint": null,
+     "accept": [
+      "illative",
+      "allative",
+      "inf3_illative"
+     ]
+    },
+    {
+     "key": "rection:translative",
+     "glosses": [
+      "to plan to become, aspire to be, run for (office) (to work towards or hope to attain a position)"
+     ],
+     "hint": null,
+     "accept": [
+      "translative"
+     ]
+    },
+    {
+     "key": "rection:inf3_illative",
+     "glosses": [
+      "to tend (to have a tendency to)"
+     ],
+     "hint": null,
+     "accept": [
+      "inf3_illative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "omistautua",
+   "frequency_rank": 11759,
+   "items": [
+    {
+     "key": "rection:allative:to",
+     "glosses": [
+      "to devote oneself, dedicate oneself (to commit oneself to a particular course of thought or action)"
+     ],
+     "hint": "to",
+     "accept": [
+      "allative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "upota",
+   "frequency_rank": 11958,
+   "items": [
+    {
+     "key": "rection:illative:in",
+     "glosses": [
+      "to sink (descend into liquid)"
+     ],
+     "hint": "in",
+     "accept": [
+      "illative"
+     ]
+    },
+    {
+     "key": "rection:illative",
+     "glosses": [
+      "to bite (e.g. of a saw)"
+     ],
+     "hint": null,
+     "accept": [
+      "illative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "kannella",
+   "frequency_rank": 12244,
+   "items": [
+    {
+     "key": "rection:elative:about",
+     "glosses": [
+      "to tattle (to notify someone of illicit behaviour)"
+     ],
+     "hint": "about",
+     "accept": [
+      "elative"
+     ]
+    },
+    {
+     "key": "rection:allative:to",
+     "glosses": [
+      "to tattle (to notify someone of illicit behaviour)"
+     ],
+     "hint": "to",
+     "accept": [
+      "allative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "valmistua",
+   "frequency_rank": 12790,
+   "items": [
+    {
+     "key": "rection:ablative+elative:from",
+     "glosses": [
+      "to graduate (to be recognized by a learning institution as having completed its requirements for a degree)"
+     ],
+     "hint": "from",
+     "accept": [
+      "elative",
+      "ablative"
+     ]
+    },
+    {
+     "key": "rection:translative:as",
+     "glosses": [
+      "to graduate (to be recognized by a learning institution as having completed its requirements for a degree)"
+     ],
+     "hint": "as",
+     "accept": [
+      "translative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "riistää",
+   "frequency_rank": 12890,
+   "items": [
+    {
+     "key": "rection:ablative",
+     "glosses": [
+      "to deprive, bereave, strip of (especially through force or violent means)"
+     ],
+     "hint": null,
+     "accept": [
+      "ablative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "todeta",
+   "frequency_rank": 13336,
+   "items": [
+    {
+     "key": "rection:translative",
+     "glosses": [
+      "to pronounce (declare authoritatively, or as a formal expert opinion)"
+     ],
+     "hint": null,
+     "accept": [
+      "translative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "säikähtää",
+   "frequency_rank": 13493,
+   "items": [
+    {
+     "key": "rection:elative+partitive:by",
+     "glosses": [
+      "to be startled/frightened/scared, take fright, jump"
+     ],
+     "hint": "by",
+     "accept": [
+      "partitive",
+      "elative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "tyytyä",
+   "frequency_rank": 13938,
+   "items": [
+    {
+     "key": "rection:illative:with",
+     "glosses": [
+      "to content oneself, settle"
+     ],
+     "hint": "with",
+     "accept": [
+      "illative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "poiketa",
+   "frequency_rank": 15507,
+   "items": [
+    {
+     "key": "rection:elative",
+     "glosses": [
+      "to differ from, be different from, depart, deviate, diverge (not to have the same traits, characteristics)",
+      "to deviate, stray, wander; to diverge, swerve, veer, divert"
+     ],
+     "hint": null,
+     "accept": [
+      "elative"
+     ]
+    },
+    {
+     "key": "rection:adessive+inessive",
+     "glosses": [
+      "to drop by, drop in (to visit without an appointment)"
+     ],
+     "hint": null,
+     "accept": [
+      "inessive",
+      "adessive"
+     ]
+    },
+    {
+     "key": "rection:inf3_inessive:to-do",
+     "glosses": [
+      "to drop by, drop in (to visit without an appointment)"
+     ],
+     "hint": "to do",
+     "accept": [
+      "inf3_inessive"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "laistaa",
+   "frequency_rank": 18434,
+   "items": [
+    {
+     "key": "rection:elative",
+     "glosses": [
+      "to shirk, neglect (to evade from one's duties or obligations)"
+     ],
+     "hint": null,
+     "accept": [
+      "elative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "haaskata",
+   "frequency_rank": 18441,
+   "items": [
+    {
+     "key": "rection:illative:on",
+     "glosses": [
+      "to waste, squander (money, time, resources, food, etc.)"
+     ],
+     "hint": "on",
+     "accept": [
+      "illative"
+     ]
+    }
+   ]
+  },
+  {
+   "word": "varustaa",
+   "frequency_rank": 19625,
+   "items": [
+    {
+     "key": "rection:adessive:with",
+     "glosses": [
+      "to equip, fit (up/out), supply, apparel, furnish; to provision; to arm, supply with arms"
+     ],
+     "hint": "with",
+     "accept": [
+      "adessive"
+     ]
+    },
+    {
+     "key": "rection:allative+illative+translative:to-be",
+     "glosses": [
+      "to equip, fit (up/out), supply, apparel, furnish; to provision; to arm, supply with arms"
+     ],
+     "hint": "to be",
+     "accept": [
+      "illative",
+      "allative",
+      "translative"
+     ]
+    },
+    {
+     "key": "rection:allative+illative:for",
+     "glosses": [
+      "to prepare, get someone ready; to make arrangements/preparations"
+     ],
+     "hint": "for",
+     "accept": [
+      "illative",
+      "allative"
+     ]
+    }
+   ]
+  }
+ ]
+}

--- a/index.html
+++ b/index.html
@@ -74,8 +74,8 @@
     <div id="drill-style-row" class="drill-style-row hidden">
       <div id="drill-style-switch" class="seg-switch" role="radiogroup" aria-label="Drill style">
         <button type="button" class="seg-btn" data-value="standard" role="radio">Standard</button>
-        <button type="button" class="seg-btn" data-value="cloze"    role="radio">Cloze</button>
-        <button type="button" class="seg-btn" data-value="rection"  role="radio">Rection</button>
+        <button type="button" class="seg-btn" data-value="cloze"    role="radio">Cloze <span class="beta-tag">(beta)</span></button>
+        <button type="button" class="seg-btn" data-value="rection"  role="radio">Rection <span class="beta-tag">(beta)</span></button>
       </div>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -68,12 +68,14 @@
       </div>
     </header>
 
-    <!-- Drill style: Standard (lemma + grammatical prompt) vs Cloze (example
-         sentence with the form blanked out). Drill view only. -->
+    <!-- Drill style: Standard (lemma + grammatical prompt), Cloze (example
+         sentence with the form blanked out), or Rection (which case does this
+         verb govern — multiple choice, verb mode only). Drill view only. -->
     <div id="drill-style-row" class="drill-style-row hidden">
       <div id="drill-style-switch" class="seg-switch" role="radiogroup" aria-label="Drill style">
         <button type="button" class="seg-btn" data-value="standard" role="radio">Standard</button>
         <button type="button" class="seg-btn" data-value="cloze"    role="radio">Cloze</button>
+        <button type="button" class="seg-btn" data-value="rection"  role="radio">Rection</button>
       </div>
     </div>
 
@@ -104,6 +106,9 @@
         <button id="submit-answer" type="button" class="submit-btn"
                 title="Submit answer" aria-label="Submit answer">&#10132;</button>
       </div>
+      <!-- Rection multiple choice: replaces the text input when the Rection
+           drill style is active. Buttons are built per-challenge by main.js. -->
+      <div id="rection-choices" class="rection-choices hidden"></div>
       <div id="feedback" class="feedback"></div>
       <div class="hint-row">
         <button id="hint-letter" type="button" class="hint-btn" title="Reveal next letter (;)">
@@ -309,6 +314,19 @@
         label to lean on. Cloze only draws on words whose example sentences
         actually contain the target form, so its pool is smaller than
         Standard's; your case, type, and frequency filters still apply.
+      </p>
+      <p>
+        <strong>Rection</strong> (verb mode only) drills which case or
+        infinitive form a verb's complement takes &mdash; the thing that makes
+        <em>uskoa <strong>jumalaan</strong></em> illative but <em>pitää
+        <strong>musiikista</strong></em> elative. Each challenge shows a verb
+        and its English sense; pick the right complement from four options
+        (keys <kbd>1</kbd>&ndash;<kbd>4</kbd> work too). Where one sense
+        governs several patterns, the English hint in the prompt (&ldquo;+
+        ___ (&lsquo;to&rsquo;)&rdquo;) tells you which one is being asked.
+        The patterns come from the rection annotations Wiktionary editors
+        attach to Finnish verb senses &mdash; about 90 common verbs and 120
+        patterns. Tests and Blitz aren't available in this style.
       </p>
 
       <h3>Full inflection table</h3>

--- a/js/data.js
+++ b/js/data.js
@@ -23,10 +23,22 @@ async function loadBlocklist() {
   }
 }
 
+// Rection data (scripts/extract_rection.py) is optional: a service worker
+// from an older deploy may serve a cached shell without the file, and the
+// drill itself must keep working — the Rection style just comes up empty.
+async function loadRection() {
+  try {
+    return await loadJson("data/rection.json");
+  } catch {
+    return { complements: [], words: [] };
+  }
+}
+
 export async function loadData() {
-  const [nouns, verbs, blocklist] = await Promise.all([
+  const [nouns, verbs, rection, blocklist] = await Promise.all([
     loadJson("data/nouns.json"),
     loadJson("data/verbs.json"),
+    loadRection(),
     loadBlocklist(),
   ]);
   if (blocklist.nouns.size) {
@@ -34,6 +46,7 @@ export async function loadData() {
   }
   if (blocklist.verbs.size) {
     verbs.words = verbs.words.filter((w) => !blocklist.verbs.has(w.word));
+    rection.words = rection.words.filter((w) => !blocklist.verbs.has(w.word));
   }
-  return { nouns, verbs };
+  return { nouns, verbs, rection };
 }

--- a/js/drill.js
+++ b/js/drill.js
@@ -247,6 +247,39 @@ function srsPick(pool, mode, schedule, floor, now) {
   return pool[pool.length - 1];
 }
 
+// ---------- rection ----------
+// A rection challenge asks which complement (case or infinitive form) a verb
+// governs, answered by multiple choice. Items come from data/rection.json
+// (parsed Wiktionary annotations — see scripts/extract_rection.py) and join
+// back to the verb objects in verbs.json for the headword, audio, examples,
+// and inflection table.
+
+export function buildRectionPool(data) {
+  const out = [];
+  if (!data.rection || !Array.isArray(data.rection.words)) return out;
+  const byWord = new Map();
+  for (const w of data.verbs.words) byWord.set(w.word, w);
+  for (const r of data.rection.words) {
+    const word = byWord.get(r.word);
+    if (!word) continue;
+    // Union of acceptable complements across ALL of this verb's items. A
+    // complement that's correct for one sense (pitää + elative "to like")
+    // must never appear as a distractor on another (pitää + partitive
+    // "to hold") — the user would be right for the wrong reasons, or worse,
+    // marked wrong for a correct pattern.
+    const exclude = [];
+    for (const item of r.items) {
+      for (const c of item.accept) {
+        if (!exclude.includes(c)) exclude.push(c);
+      }
+    }
+    for (const item of r.items) {
+      out.push({ word, key: item.key, rection: item, rectionExclude: exclude });
+    }
+  }
+  return out;
+}
+
 export function checkAnswer(challenge, input) {
   const expected = challenge.word.inflections[challenge.key];
   const ok = normalize(input) === normalize(expected);

--- a/js/labels.js
+++ b/js/labels.js
@@ -13,6 +13,51 @@ function byId(list, id) {
   return list.find((x) => x.id === id);
 }
 
+// Rection complement labels. The drill answer is a case (or infinitive form)
+// name, so each option carries a quick reminder of what that complement looks
+// like — the question word for locative cases, the suffix or a model form
+// elsewhere. Infinitive complements use the school-grammar names with a
+// "tehdä" model so they're recognizable without knowing the numbering.
+const COMPLEMENT_LABELS = {
+  nominative:    "nominative (mikä)",
+  genitive:      "genitive (kenen / minkä)",
+  partitive:     "partitive (mitä)",
+  accusative:    "accusative (object form)",
+  inessive:      "inessive (missä)",
+  elative:       "elative (mistä)",
+  illative:      "illative (mihin)",
+  adessive:      "adessive (millä)",
+  ablative:      "ablative (miltä)",
+  allative:      "allative (mille)",
+  essive:        "essive (-na/-nä)",
+  translative:   "translative (-ksi)",
+  abessive:      "abessive (-tta/-ttä)",
+  instructive:   "instructive (-in)",
+  comitative:    "comitative (-ine-)",
+  inf1:          "basic infinitive (tehdä)",
+  inf2_inessive: "E-infinitive inessive (tehdessä)",
+  inf3_illative: "MA-infinitive illative (tekemään)",
+  inf3_elative:  "MA-infinitive elative (tekemästä)",
+  inf3_inessive: "MA-infinitive inessive (tekemässä)",
+};
+
+export function complementLabel(id) {
+  return COMPLEMENT_LABELS[id] || id;
+}
+
+// Label for a rection item key: "rection:<comp>[+<comp>…][:<hint-slug>]".
+// Used by the stats tables, where the full per-option labels would be noisy —
+// strip the parenthetical reminders and re-space the hint slug.
+export function rectionLabel(key) {
+  const parts = key.split(":");
+  const comps = (parts[1] || "")
+    .split("+")
+    .map((c) => complementLabel(c).replace(/\s*\(.*\)$/, ""))
+    .join(" or ");
+  const hint = parts[2] ? ` ‘${parts[2].replace(/-/g, " ")}’` : "";
+  return `+ ${comps}${hint}`;
+}
+
 export function nounLabel(key, cfg) {
   const [caseId, numberId] = key.split("_");
   const c = byId(cfg.nounCases.cases, caseId);

--- a/js/main.js
+++ b/js/main.js
@@ -5,9 +5,9 @@ import { loadConfig } from "./config.js";
 import { loadData } from "./data.js";
 import {
   buildNounPool, buildVerbPool, nextChallenge, checkAnswer,
-  buildClozePool, clozeBlankRegex, parseVerbKey,
+  buildClozePool, clozeBlankRegex, buildRectionPool, parseVerbKey,
 } from "./drill.js";
-import { nounLabel, verbLabel } from "./labels.js";
+import { nounLabel, verbLabel, complementLabel } from "./labels.js";
 import {
   loadNounFilters, saveNounFilters, renderNounFilters,
   loadVerbFilters, saveVerbFilters, renderVerbFilters,
@@ -51,6 +51,11 @@ const state = {
   current: null,            // { word, key }
   awaitingNext: false,      // true after a right/wrong/shown-answer, Enter advances
   hintsShown: 0,            // number of letters revealed for current challenge
+  // Per-challenge multiple-choice state for the Rection drill style:
+  // { options: [complementId…], picked: complementId | null }. Lives outside
+  // state.current because pool entries are shared objects — stashing answered
+  // state on them would leak into the next time the same item is drawn.
+  rectionRound: null,
   scoredThisChallenge: false, // stats recorded at most once per challenge
   nounFilters: null,
   verbFilters: null,
@@ -112,6 +117,7 @@ const el = {
   clozeLine:       document.getElementById("cloze-line"),
   clozeFi:         document.getElementById("cloze-fi"),
   clozeEn:         document.getElementById("cloze-en"),
+  rectionChoices:  document.getElementById("rection-choices"),
   inflectionModal: document.getElementById("inflection-modal"),
   inflectionTitle: document.getElementById("inflection-title"),
   inflectionNote:  document.getElementById("inflection-note"),
@@ -192,21 +198,44 @@ function render() {
   }
   const { word, key } = state.current;
   el.headword.textContent = word.word;
-  el.translation.textContent = (word.translations || []).slice(0, 2).join(", ");
-  // Cloze style replaces the grammatical prompt + examples with the blanked
-  // sentence. Falls back to the standard prompt if the blank can't be
-  // located in the original text (shouldn't happen — the pool builder
-  // verified containment on the normalized form — but belt + braces).
-  const cloze = clozeActive() && renderClozeLine();
-  el.targetForm.classList.toggle("hidden", !!cloze);
-  el.clozeLine.classList.toggle("hidden", !cloze);
-  if (cloze) {
-    el.examples.innerHTML = "";
-    el.examples.classList.add("hidden");
+  // Rection style replaces the typed-answer flow entirely: the prompt is the
+  // verb plus a blank ("uskoa + ___"), the gloss disambiguates which sense is
+  // being asked, and the answer comes from the multiple-choice buttons.
+  const rection = rectionActive() && !!state.current.rection;
+  el.rectionChoices.classList.toggle("hidden", !rection);
+  if (rection) {
+    const item = state.current.rection;
+    el.translation.textContent = item.glosses.join("; ");
+    el.targetForm.classList.remove("hidden");
+    el.clozeLine.classList.add("hidden");
+    el.targetForm.textContent =
+      `${word.word} + ___` + (item.hint ? ` (‘${item.hint}’)` : "");
+    renderRectionChoices();
+    // Examples often use the rection complement, so they'd spoil the answer —
+    // hold them back until the challenge is resolved.
+    if (state.awaitingNext || state.scoredThisChallenge) {
+      renderExamples(word);
+    } else {
+      el.examples.innerHTML = "";
+      el.examples.classList.add("hidden");
+    }
   } else {
-    const label = state.mode === "noun" ? nounLabel(key, state.cfg) : verbLabel(key, state.cfg);
-    el.targetForm.textContent = label;
-    renderExamples(word, word.inflections[key]);
+    el.translation.textContent = (word.translations || []).slice(0, 2).join(", ");
+    // Cloze style replaces the grammatical prompt + examples with the blanked
+    // sentence. Falls back to the standard prompt if the blank can't be
+    // located in the original text (shouldn't happen — the pool builder
+    // verified containment on the normalized form — but belt + braces).
+    const cloze = clozeActive() && renderClozeLine();
+    el.targetForm.classList.toggle("hidden", !!cloze);
+    el.clozeLine.classList.toggle("hidden", !cloze);
+    if (cloze) {
+      el.examples.innerHTML = "";
+      el.examples.classList.add("hidden");
+    } else {
+      const label = state.mode === "noun" ? nounLabel(key, state.cfg) : verbLabel(key, state.cfg);
+      el.targetForm.textContent = label;
+      renderExamples(word, word.inflections[key]);
+    }
   }
   // Only reveal the challenge/answer row when we're actually on the drill
   // view. Some settings (excludeLong, maxAnswerLength, frequencyCap) rebuild
@@ -277,9 +306,28 @@ function renderExamples(word, targetForm) {
   el.examples.classList.remove("hidden");
 }
 
-// ---------- cloze rendering ----------
+// ---------- drill style helpers ----------
+// The persisted drillStyle can be "rection" while the user is on the noun
+// tab, where rection makes no sense. Rather than mutating the saved setting
+// on every mode switch, the EFFECTIVE style falls back to standard outside
+// verb mode — switch back to Verbs and rection resumes where you left it.
+function effectiveDrillStyle() {
+  const s = (state.settings && state.settings.drillStyle) || "standard";
+  return s === "rection" && state.mode !== "verb" ? "standard" : s;
+}
+
 function clozeActive() {
-  return !!(state.settings && state.settings.drillStyle === "cloze");
+  return effectiveDrillStyle() === "cloze";
+}
+
+function rectionActive() {
+  return effectiveDrillStyle() === "rection";
+}
+
+// Stats + SRS bucket rection outcomes under their own mode id, so rection
+// keys never collide with verb inflection keys in byItem or the schedule.
+function statsMode() {
+  return rectionActive() ? "rection" : state.mode;
 }
 
 // Build the blanked sentence into #cloze-fi. Returns false when the current
@@ -330,6 +378,90 @@ function revealCloze() {
     blank.textContent = expected;
     blank.classList.add("filled");
   }
+}
+
+// ---------- rection rendering ----------
+const RECTION_OPTION_COUNT = 4;
+
+function shuffleInPlace(arr) {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+// Build the option set for the current rection challenge: one randomly chosen
+// acceptable complement plus distractors drawn from the dataset-wide
+// vocabulary, minus anything that's a correct answer for ANY sense of this
+// verb (see buildRectionPool for why).
+function buildRectionRound() {
+  const { rection, rectionExclude } = state.current;
+  const vocab = (state.data.rection && state.data.rection.complements) || [];
+  const accept = rection.accept;
+  const correct = accept[Math.floor(Math.random() * accept.length)];
+  const distractors = shuffleInPlace(
+    vocab.filter((c) => !(rectionExclude || accept).includes(c))
+  );
+  const options = [correct, ...distractors.slice(0, RECTION_OPTION_COUNT - 1)];
+  return { options: shuffleInPlace(options), picked: null };
+}
+
+// (Re)paint the choice buttons. Builds the round lazily on first paint per
+// challenge; after the challenge resolves, repaints disabled with the
+// correct/wrong coloring so view switches don't lose the answered state.
+function renderRectionChoices() {
+  if (!state.rectionRound) state.rectionRound = buildRectionRound();
+  const { options, picked } = state.rectionRound;
+  const accept = state.current.rection.accept;
+  const resolved = state.awaitingNext || state.scoredThisChallenge;
+  el.rectionChoices.innerHTML = "";
+  options.forEach((c, i) => {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "rection-choice";
+    const kbd = document.createElement("kbd");
+    kbd.textContent = String(i + 1);
+    btn.appendChild(kbd);
+    btn.appendChild(document.createTextNode(" " + complementLabel(c)));
+    if (resolved) {
+      btn.disabled = true;
+      if (accept.includes(c)) btn.classList.add("correct");
+      else if (picked === c) btn.classList.add("wrong");
+    } else {
+      btn.addEventListener("click", () => answerRection(c));
+    }
+    el.rectionChoices.appendChild(btn);
+  });
+}
+
+// "uskoa + illative (mihin) (‘in’)" — the full pattern, shown as feedback
+// once the challenge resolves so the user always sees the complete rection,
+// not just right/wrong.
+function formatRectionPattern() {
+  const { word, rection } = state.current;
+  const comps = rection.accept.map(complementLabel).join(" or ");
+  return `${word.word} + ${comps}` + (rection.hint ? ` (‘${rection.hint}’)` : "");
+}
+
+function answerRection(choice) {
+  if (!state.current || state.awaitingNext || state.scoredThisChallenge) return;
+  const ok = state.current.rection.accept.includes(choice);
+  state.rectionRound.picked = choice;
+  state.awaitingNext = true;
+  score(ok ? "correct" : "wrong");
+  if (!ok) buzzIfWrong();
+  setFeedback(`${ok ? "✓" : "✗"} ${formatRectionPattern()}`, ok ? "ok" : "bad");
+  renderRectionChoices();
+  renderExamples(state.current.word);
+  // Auto-advance — a beat longer on a miss so the full pattern can be read.
+  // The challenge-identity check (not just awaitingNext) keeps a stale timer
+  // from skipping ahead when the user Enter-advanced and answered the next
+  // challenge before this one's window elapsed.
+  const answered = state.current;
+  setTimeout(() => {
+    if (state.awaitingNext && state.current === answered) newChallenge();
+  }, ok ? 1400 : 2600);
 }
 
 function appendHighlighted(parent, text, re) {
@@ -390,12 +522,17 @@ function setStatus(text) { el.statusLine.textContent = text; }
 
 function updateStatus() {
   const count = state.pool.length;
-  const style = clozeActive() ? " cloze" : "";
+  const styleId = effectiveDrillStyle();
+  const style = styleId === "standard" ? "" : ` ${styleId}`;
   let suffix = "";
   if (count === 0) {
-    suffix = clozeActive()
-      ? " \u2014 no example sentences match these filters; broaden them or switch to Standard"
-      : " \u2014 all filtered out, enable something above";
+    if (rectionActive()) {
+      suffix = " \u2014 no rection data within the current frequency cap; raise it under Options";
+    } else if (clozeActive()) {
+      suffix = " \u2014 no example sentences match these filters; broaden them or switch to Standard";
+    } else {
+      suffix = " \u2014 all filtered out, enable something above";
+    }
   }
   setStatus(`${state.mode}${style} mode \u2022 ${count.toLocaleString()} possible challenges${suffix}`);
 }
@@ -425,7 +562,7 @@ function score(outcome) {
   // counting e.g. "wrong" then "shown" on the same card.
   if (state.scoredThisChallenge) return;
   if (!state.current) return;
-  recordOutcome(state.stats, state.mode, state.current, outcome);
+  recordOutcome(state.stats, statsMode(), state.current, outcome);
   saveStats(state.stats);
   state.scoredThisChallenge = true;
 
@@ -439,10 +576,10 @@ function score(outcome) {
   // as custom dimensions in GA4 admin if you want to filter the default
   // reports by them — without that, params still land in Explorations /
   // DebugView, just not the headline reports.
-  track("drill_answer", { mode: state.mode, outcome });
+  track("drill_answer", { mode: statsMode(), outcome });
   if (!sessionFirstAnswerFired) {
     sessionFirstAnswerFired = true;
-    track("session_first_answer", { mode: state.mode });
+    track("session_first_answer", { mode: statsMode() });
   }
 
   if (outcome === "correct") {
@@ -461,7 +598,7 @@ function score(outcome) {
 function recordOutcomeToSchedule(outcome) {
   if (!state.current) return;
   const cap = CAP_PRESETS[state.settings.srsCap] || CAP_PRESETS.balanced;
-  const id = `${state.mode}|${state.current.word.word}|${state.current.key}`;
+  const id = `${statsMode()}|${state.current.word.word}|${state.current.key}`;
   const now = Date.now();
 
   if (outcome === "correct") {
@@ -548,6 +685,10 @@ function refreshStatsPanel() {
 // opens and the test is marked finished.
 
 function openTestModal() {
+  if (rectionActive()) {
+    setStatus("Test mode isn't available in the Rection style — switch to Standard or Cloze first.");
+    return;
+  }
   if (state.pool.length === 0) {
     setStatus("No challenges in the current pool — enable a filter first.");
     return;
@@ -732,6 +873,10 @@ function blitzActive() {
 }
 
 function openBlitzModal() {
+  if (rectionActive()) {
+    setStatus("Blitz isn't available in the Rection style — switch to Standard or Cloze first.");
+    return;
+  }
   if (state.pool.length === 0) {
     setStatus("No challenges in the current pool — enable a filter first.");
     return;
@@ -1035,7 +1180,7 @@ function newChallenge(opts) {
   const capPreset = CAP_PRESETS[state.settings && state.settings.srsCap] || CAP_PRESETS.balanced;
   state.current = nextChallenge(state.pool, state.current, {
     priority,
-    mode:     state.mode,
+    mode:     statsMode(),
     stats:    state.stats,
     schedule: state.schedule,
     srsFloor: capPreset.floor,
@@ -1044,6 +1189,7 @@ function newChallenge(opts) {
   state.awaitingNext = false;
   state.hintsShown = 0;
   state.scoredThisChallenge = false;
+  state.rectionRound = null;
   el.answer.value = "";
   setFeedback("");
   if (!state.current) {
@@ -1062,7 +1208,9 @@ function newChallenge(opts) {
   // skip it entirely when the caller asked us to (filter toggles, preset
   // applies) so we don't scroll mobile users away from the control they're
   // touching.
-  if (state.view === "drill" && !(opts && opts.suppressFocus)) el.answer.focus();
+  if (state.view === "drill" && !rectionActive() && !(opts && opts.suppressFocus)) {
+    el.answer.focus();
+  }
 }
 
 function submit() {
@@ -1141,6 +1289,7 @@ function buzzIfWrong() {
 function revealNextLetter() {
   if (!state.current || state.awaitingNext) return;
   if (blitzActive()) return;   // hints disabled during blitz
+  if (rectionActive()) return; // no typed answer to reveal letters of
   const expected = state.current.word.inflections[state.current.key];
   const input = el.answer.value;
   let correctPrefixLen = 0;
@@ -1175,6 +1324,7 @@ function revealNextLetter() {
 function showFullAnswer() {
   if (!state.current) return;
   if (blitzActive()) return;   // hints disabled during blitz
+  if (rectionActive()) return; // multiple choice — nothing to type-reveal
   if (testActive()) {
     score("shown");
     recordTestAnswer("shown", el.answer.value);
@@ -1206,19 +1356,30 @@ function skipChallenge() {
 // ---------- mode + filters ----------
 // `opts.suppressFocus` is forwarded to newChallenge — see the note there.
 function rebuildPool(opts) {
-  let pool = state.mode === "noun"
-    ? buildNounPool(state.data, state.nounFilters)
-    : buildVerbPool(state.data, state.verbFilters);
+  let pool;
+  if (rectionActive()) {
+    // Rection has its own challenge set — the case/tense filter grids don't
+    // apply (and are hidden); only the frequency cap below carries over.
+    pool = buildRectionPool(state.data);
+  } else {
+    pool = state.mode === "noun"
+      ? buildNounPool(state.data, state.nounFilters)
+      : buildVerbPool(state.data, state.verbFilters);
 
-  // Optional length filter — drops any challenge whose expected answer is
-  // longer than the configured threshold. Applied as a post-filter so the
-  // main pool builders stay agnostic.
-  if (state.settings && state.settings.excludeLong) {
-    const max = state.settings.maxAnswerLength;
-    pool = pool.filter(({ word, key }) => {
-      const ans = word.inflections[key] || "";
-      return ans.length <= max;
-    });
+    // Optional length filter — drops any challenge whose expected answer is
+    // longer than the configured threshold. Applied as a post-filter so the
+    // main pool builders stay agnostic.
+    if (state.settings && state.settings.excludeLong) {
+      const max = state.settings.maxAnswerLength;
+      pool = pool.filter(({ word, key }) => {
+        const ans = word.inflections[key] || "";
+        return ans.length <= max;
+      });
+    }
+
+    // Cloze style: keep only challenges whose word has an example sentence
+    // containing the target form, and remember which example it was.
+    if (clozeActive()) pool = buildClozePool(pool);
   }
 
   // Optional frequency cap — restrict to words whose best inflected-form rank
@@ -1230,10 +1391,6 @@ function rebuildPool(opts) {
       return typeof r === "number" && r <= cap;
     });
   }
-
-  // Cloze style: keep only challenges whose word has an example sentence
-  // containing the target form, and remember which example it was.
-  if (clozeActive()) pool = buildClozePool(pool);
 
   state.pool = pool;
   updateStatus();
@@ -1262,11 +1419,13 @@ function setView(view) {
   el.challenge.classList.toggle("hidden", !(drill && state.current));
   el.answerRow.classList.toggle("hidden", !(drill && state.current));
   el.drillStyleRow.classList.toggle("hidden", !drill);
+  // Rection ignores the filter grids and presets entirely (its pool isn't
+  // case/tense-shaped), so they hide along with the rest of the chrome.
   el.filtersNoun.classList.toggle("hidden", !(drill && state.mode === "noun"));
-  el.filtersVerb.classList.toggle("hidden", !(drill && state.mode === "verb"));
+  el.filtersVerb.classList.toggle("hidden", !(drill && state.mode === "verb" && !rectionActive()));
   // Presets live between filters and test mode; drill-only, and the list is
   // per-mode so it re-renders on any mode switch that reaches this code path.
-  el.presetsPanel.classList.toggle("hidden", !drill);
+  el.presetsPanel.classList.toggle("hidden", !(drill && !rectionActive()));
   if (drill) renderPresets();
   // Stats / status line are drill-only; settings now live in Options. The
   // test hud is gated on both: only show it on the drill view AND when a
@@ -1296,6 +1455,10 @@ function setMode(mode) {
     cancelBlitz();
   }
   state.mode = mode;
+  // The effective drill style can change with the mode (rection is verb-only),
+  // so the switch highlight and the body chrome both need a refresh here.
+  renderDrillStyleSwitch();
+  applyRectionChrome();
   setView("drill");
   // Rebuild the pool on a real mode switch, OR whenever there's no current
   // challenge on screen. The second case matters on first boot: state.mode
@@ -1308,11 +1471,16 @@ function setMode(mode) {
   else updateStatus();
 }
 
-// ---------- drill style (standard / cloze) ----------
+// ---------- drill style (standard / cloze / rection) ----------
 function renderDrillStyleSwitch() {
   if (!el.drillStyleSwitch) return;
-  const pref = (state.settings && state.settings.drillStyle) || "standard";
+  const pref = effectiveDrillStyle();
   for (const btn of el.drillStyleSwitch.querySelectorAll(".seg-btn")) {
+    // Rection only exists for verbs — hide its button on the noun tab rather
+    // than letting it sit there as a dead control.
+    if (btn.dataset.value === "rection") {
+      btn.classList.toggle("hidden", state.mode !== "verb");
+    }
     const active = btn.dataset.value === pref;
     btn.classList.toggle("active", active);
     btn.setAttribute("aria-checked", active ? "true" : "false");
@@ -1325,11 +1493,17 @@ function updateAnswerPlaceholder() {
     : "type the form and press Enter";
 }
 
+// Swap the answer chrome for rection: CSS keyed off this body class hides the
+// text input and the hint buttons that assume a typed answer (Skip stays).
+function applyRectionChrome() {
+  document.body.classList.toggle("rection-mode", rectionActive());
+}
+
 function setDrillStyle(style) {
-  if (style !== "standard" && style !== "cloze") return;
+  if (style !== "standard" && style !== "cloze" && style !== "rection") return;
   if (state.settings.drillStyle === style) return;
-  // The cloze pool is a different challenge set, so switching style mid-test
-  // or mid-blitz invalidates the run — same confirm flow as a mode switch.
+  // Each style is a different challenge set, so switching mid-test or
+  // mid-blitz invalidates the run — same confirm flow as a mode switch.
   if (testActive()) {
     if (!confirm("Switching drill style will cancel the current test. Continue?")) return;
     cancelTest();
@@ -1342,8 +1516,11 @@ function setDrillStyle(style) {
   saveSettings(state.settings);
   renderDrillStyleSwitch();
   updateAnswerPlaceholder();
+  applyRectionChrome();
   track("drill_style", { style });
   rebuildPool();
+  // Filter/preset panel visibility depends on the style — re-sync the view.
+  if (state.view === "drill") setView("drill");
 }
 
 // ---------- full inflection table ----------
@@ -1358,7 +1535,8 @@ function openInflectionTable() {
   if (blitzActive() || testActive()) return;
   const { word, key } = state.current;
   const expected = word.inflections[key];
-  const concealed = !(state.awaitingNext || state.scoredThisChallenge);
+  // Rection answers are case names, not table cells — nothing to mask.
+  const concealed = !rectionActive() && !(state.awaitingNext || state.scoredThisChallenge);
   el.inflectionTitle.textContent = word.word;
   el.inflectionNote.classList.toggle("hidden", !concealed);
   el.inflectionBody.innerHTML = "";
@@ -1896,6 +2074,26 @@ async function boot() {
       }
     });
 
+    // Rection keyboard support: the answer input is hidden in this style, so
+    // its keydown handler never fires. 1–4 pick a choice, Enter advances once
+    // the challenge is resolved, "-" skips. Skipped while typing in any other
+    // control or while a modal is up.
+    document.addEventListener("keydown", (e) => {
+      if (!rectionActive() || state.view !== "drill" || !state.current) return;
+      const t = e.target;
+      if (t && (t.tagName === "INPUT" || t.tagName === "TEXTAREA" || t.tagName === "SELECT")) return;
+      if (!el.inflectionModal.classList.contains("hidden")) return;
+      if (e.key === "Enter") {
+        if (state.awaitingNext) { e.preventDefault(); newChallenge(); }
+        return;
+      }
+      if (e.key === "-") { e.preventDefault(); skipChallenge(); return; }
+      if (e.key >= "1" && e.key <= "4") {
+        const btn = el.rectionChoices.querySelectorAll(".rection-choice")[Number(e.key) - 1];
+        if (btn && !btn.disabled) { e.preventDefault(); btn.click(); }
+      }
+    });
+
     // On-screen submit button — same path as Enter. Mousedown-preventDefault
     // keeps focus in the answer input so the mobile keyboard doesn't dismiss.
     if (el.submitAnswer) {
@@ -2006,6 +2204,7 @@ async function importStats(file) {
       renderThemeSwitch();
       renderDrillStyleSwitch();
       updateAnswerPlaceholder();
+      applyRectionChrome();
     }
     if (data.schedule && data.schedule.byItem) {
       state.schedule = { byItem: data.schedule.byItem };

--- a/js/settings.js
+++ b/js/settings.js
@@ -26,8 +26,10 @@ export function defaultSettings() {
                               // used by scripts/extract.py at build time.
     theme:             "system", // "system" | "light" | "dark"
     // Challenge presentation. "standard" shows lemma + grammatical prompt;
-    // "cloze" shows an example sentence with the target form blanked out.
-    // Cloze restricts the pool to challenges that have a usable example.
+    // "cloze" shows an example sentence with the target form blanked out;
+    // "rection" (verb mode only) asks which complement a verb governs,
+    // answered by multiple choice. Cloze restricts the pool to challenges
+    // with a usable example; rection uses its own pool (data/rection.json).
     drillStyle:        "standard",
     // Gamification is opt-in for new users. Existing users with a stored
     // settings blob keep streak visibility via the migration below, so this

--- a/js/stats.js
+++ b/js/stats.js
@@ -44,6 +44,7 @@ export function defaultStats() {
     byVerbPolarity: {},
     byVerbPerson:   {},
     byVerbGroup:    {},
+    byRection:      {},
     byItem:         {},
     // Timeline for the "avg reviews/day" summary. We don't store per-day
     // buckets — just the first-ever review timestamp and a running counter —
@@ -69,6 +70,7 @@ export function loadStats() {
     byVerbPolarity: stored.byVerbPolarity || {},
     byVerbPerson:   stored.byVerbPerson   || {},
     byVerbGroup:    stored.byVerbGroup    || {},
+    byRection:      stored.byRection      || {},
     byItem:         stored.byItem         || {},
     // Migration: older stores don't have these fields. Leaving firstReviewAt
     // null means the first recordOutcome after update stamps "now" — we'd
@@ -101,7 +103,7 @@ export function itemId(mode, challenge) {
 
 /**
  * Record one outcome against the right dimension buckets.
- *   mode:      "noun" | "verb"
+ *   mode:      "noun" | "verb" | "rection"
  *   challenge: { word, key }
  *   outcome:   "correct" | "wrong" | "shown" | "skipped"
  */
@@ -120,6 +122,12 @@ export function recordOutcome(stats, mode, challenge, outcome) {
   if (mode === "noun") {
     bump(stats.byNounCase,  challenge.key,        outcome);
     bump(stats.byNounGroup, challenge.word.group, outcome);
+  } else if (mode === "rection") {
+    // Rection keys aren't verb inflection keys — parseVerbKey would
+    // misclassify them, so they get their own dimension and skip the
+    // tense/voice/polarity/person buckets entirely.
+    if (!stats.byRection) stats.byRection = {};
+    bump(stats.byRection, challenge.key, outcome);
   } else {
     const p = parseVerbKey(challenge.key);
     bump(stats.byVerbTense,    p.tense,             outcome);

--- a/js/stats_ui.js
+++ b/js/stats_ui.js
@@ -2,13 +2,14 @@
 // Pure DOM, no framework.
 
 import { summarize, summarizeByWord, accuracy, averageReviewsPerDay } from "./stats.js";
-import { nounLabel, verbLabel } from "./labels.js";
+import { nounLabel, verbLabel, rectionLabel } from "./labels.js";
 
 // UI-only state for the per-word tables. Persists across re-renders (toggle
 // open/close, stats record, etc.) so the user's sort + search don't reset.
 const wordUI = {
-  noun: { sort: "most-wrong", query: "", expanded: false },
-  verb: { sort: "most-wrong", query: "", expanded: false },
+  noun:    { sort: "most-wrong", query: "", expanded: false },
+  verb:    { sort: "most-wrong", query: "", expanded: false },
+  rection: { sort: "most-wrong", query: "", expanded: false },
 };
 
 // Show this many rows by default before the user clicks "Show all".
@@ -189,7 +190,8 @@ function escapeHtml(s) {
 function wordSectionBlock(mode, cfg, stats) {
   const ui = wordUI[mode];
   const labelFor = (key) =>
-    mode === "noun" ? nounLabel(key, cfg) : verbLabel(key, cfg);
+    mode === "noun"    ? nounLabel(key, cfg) :
+    mode === "rection" ? rectionLabel(key)   : verbLabel(key, cfg);
 
   const sec = document.createElement("section");
   sec.className = "stats-section stats-words";
@@ -387,6 +389,25 @@ export function renderStats(root, cfg, stats) {
   ));
   verbWrap.appendChild(wordSectionBlock("verb", cfg, stats));
   root.appendChild(verbWrap);
+
+  // ----- rection breakdowns -----
+  // Only rendered once the user has actually drilled rection — unlike the
+  // noun/verb groups, this style is off the beaten path and an always-on
+  // "No attempts yet" block would just be noise.
+  const rectionRows = summarize(stats.byRection || {});
+  if (rectionRows.length > 0) {
+    const rectionWrap = document.createElement("div");
+    rectionWrap.className = "stats-group";
+    const rectionHead = document.createElement("h2");
+    rectionHead.textContent = "Verb rection";
+    rectionWrap.appendChild(rectionHead);
+
+    rectionWrap.appendChild(sectionBlock(
+      "By complement", rectionRows, (id) => rectionLabel(id)
+    ));
+    rectionWrap.appendChild(wordSectionBlock("rection", cfg, stats));
+    root.appendChild(rectionWrap);
+  }
 }
 
 // Silence unused-import warning from accuracy — kept as a convenience export.

--- a/js/version.js
+++ b/js/version.js
@@ -4,4 +4,4 @@
 // minor bump (1.x.0) for new features, major bump (x.0.0) for breaking
 // changes. Remember to also update CACHE_VERSION in sw.js to match.
 // (0.13 was skipped out of superstition; 1.3 ships anyway — owner's call.)
-export const APP_VERSION = "1.4.0";
+export const APP_VERSION = "1.4.1";

--- a/js/version.js
+++ b/js/version.js
@@ -4,4 +4,4 @@
 // minor bump (1.x.0) for new features, major bump (x.0.0) for breaking
 // changes. Remember to also update CACHE_VERSION in sw.js to match.
 // (0.13 was skipped out of superstition; 1.3 ships anyway — owner's call.)
-export const APP_VERSION = "1.3.0";
+export const APP_VERSION = "1.4.0";

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -23,9 +23,12 @@ pip install -r scripts/requirements.txt
 ## How it runs (once Phase 1 is built)
 
 ```
-python scripts/download.py      # grabs kaikki.org data + frequency list
-python scripts/extract.py       # filters and writes data/nouns.json + verbs.json
+python scripts/download.py        # grabs kaikki.org data + frequency list
+python scripts/extract.py         # filters and writes data/nouns.json + verbs.json
+python scripts/extract_rection.py # parses rection annotations out of verbs.json
+                                  # into data/rection.json (no network needed)
 ```
 
 Re-run these when you want fresh words or change filters (e.g. frequency cutoff,
-group mappings in `config/noun_groups.json`).
+group mappings in `config/noun_groups.json`). `extract_rection.py` reads
+`data/verbs.json`, so run it after `extract.py`.

--- a/scripts/extract_rection.py
+++ b/scripts/extract_rection.py
@@ -1,0 +1,203 @@
+"""
+Build data/rection.json from the rection annotations already present in
+data/verbs.json.
+
+English Wiktionary marks verb rection (which case or infinitive form a verb's
+complement takes) inside the sense gloss as a bracketed editorial note, e.g.
+
+    "to believe, have faith [with illative 'in'] (someone's abilities ...)"
+    "to hold [with partitive; or with elative 'onto' (often with kiinni)] (...)"
+    "to speak, talk [with elative 'about, of' and allative 'to'] (...)"
+
+Those brackets travel verbatim into the `translations` field that
+scripts/extract.py copies out of the kaikki.org dump, so this script needs no
+network access and no re-download — it parses what's already shipped. The
+annotations are human-written Wiktionary content (CC BY-SA), not generated.
+
+Annotation grammar, as observed across the dataset:
+  - `;`-separated clauses are alternative patterns for the same sense
+  - `and` / `along with` joins complements with DIFFERENT roles
+    ("elative 'about' and allative 'to'" — two separate things to learn)
+  - `or` joins interchangeable cases within one role
+    ("with illative or allative")
+  - a quoted gloss after a case is the English meaning of that complement
+  - `<case> of third infinitive` is the MA-infinitive in that case
+    ("illative of third infinitive 'to do'" → tekemään)
+  - parentheticals are usage conditions, not rection — stripped before parsing
+
+Each (verb, role) pair becomes one drill item: the prompt shows the verb, its
+gloss, and the role's English hint (if any); the acceptable answers are the
+role's interchangeable complements. Roles whose hints are missing get merged
+per-verb-sense, since without a hint the drill question can't distinguish them.
+
+Run:  python scripts/extract_rection.py
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+DATA = ROOT / "data"
+
+CASES = (
+    "nominative|genitive|partitive|inessive|elative|illative|adessive|"
+    "ablative|allative|essive|translative|abessive|instructive|comitative|"
+    "accusative"
+)
+ORDINAL = {"first": "1", "second": "2", "third": "3"}
+
+# One complement mention: a case or infinitive, optionally "of Nth infinitive",
+# optionally followed by a curly-quoted English hint.
+TOKEN = re.compile(
+    rf"\b({CASES}|first infinitive|second infinitive|third infinitive)\b"
+    r"(?:\s+of\s+(first|second|third)\s+infinitive)?"
+    r"(?:\s+‘([^’]*)’)?"
+)
+
+BRACKET = re.compile(r"\s*\[([^\]]*)\]")
+PAREN = re.compile(r"\([^()]*\)")
+
+
+def parse_segment(seg: str) -> dict | None:
+    """One role segment → {complements: [...], hint: str|None} or None."""
+    # Complements expressed through participles or verbal nouns aren't case
+    # rection in the drillable sense — skip those segments entirely.
+    if "participle" in seg or "verbal noun" in seg:
+        return None
+    comps: list[str] = []
+    hint: str | None = None
+    for m in TOKEN.finditer(seg):
+        base, ordinal, h = m.group(1), m.group(2), m.group(3)
+        if base.endswith("infinitive"):
+            comp = f"inf{ORDINAL[base.split()[0]]}"
+        elif ordinal:
+            comp = f"inf{ORDINAL[ordinal]}_{base}"
+        else:
+            comp = base
+        if comp not in comps:
+            comps.append(comp)
+        if h:
+            hint = h.strip()
+    if not comps:
+        return None
+    return {"complements": comps, "hint": hint}
+
+
+def parse_annotation(text: str) -> list[dict]:
+    """Bracket text → list of role candidates [{complements, hint}]."""
+    # Strip usage-condition parentheticals ("(of direction)", "(uncommon)")
+    # so e.g. "(with adjectives or participles) with ablative" isn't dropped
+    # by the participle filter. Hints use curly quotes, so nothing is lost.
+    cleaned = PAREN.sub(" ", text)
+    candidates = []
+    for clause in re.split(r";\s*(?:or\s+)?", cleaned):
+        for seg in re.split(r",?\s+(?:and|along with)\s+", clause):
+            parsed = parse_segment(seg)
+            if parsed:
+                candidates.append(parsed)
+    return candidates
+
+
+def merge_candidates(candidates: list[dict]) -> list[dict]:
+    """Group role candidates by hint.
+
+    Hintless candidates from alternative clauses collapse into one item whose
+    acceptable set is the union — without a hint the prompt can't tell the
+    alternatives apart, so all of them must count as correct. Hinted
+    candidates stay separate items (the hint disambiguates the prompt).
+    """
+    by_hint: dict[str | None, list[str]] = {}
+    for c in candidates:
+        acc = by_hint.setdefault(c["hint"], [])
+        for comp in c["complements"]:
+            if comp not in acc:
+                acc.append(comp)
+    return [{"accept": comps, "hint": hint} for hint, comps in by_hint.items()]
+
+
+def slug(text: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
+
+
+def display_gloss(gloss: str) -> str:
+    """Strip the rection bracket; trim an over-long trailing parenthetical."""
+    g = BRACKET.sub("", gloss)
+    g = re.sub(r"\s{2,}", " ", g).strip().strip(";").strip()
+    if len(g) > 120:
+        cut = g.find(" (")
+        if 20 < cut < 120:
+            g = g[:cut].rstrip(",;: ")
+    return g
+
+
+def main() -> int:
+    verbs = json.loads((DATA / "verbs.json").read_text(encoding="utf-8"))
+
+    out_words = []
+    vocab: set[str] = set()
+    n_items = 0
+
+    for w in verbs["words"]:
+        # key → item, keyed on (accept-set, hint) so identical patterns from
+        # different glosses of the same verb merge instead of duplicating.
+        items: dict[str, dict] = {}
+        for gloss in w.get("translations") or []:
+            for m in BRACKET.finditer(gloss):
+                merged = merge_candidates(parse_annotation(m.group(1)))
+                if not merged:
+                    continue
+                shown = display_gloss(gloss)
+                for item in merged:
+                    key = "rection:" + "+".join(sorted(item["accept"]))
+                    if item["hint"]:
+                        key += ":" + slug(item["hint"])
+                    existing = items.get(key)
+                    if existing:
+                        if shown not in existing["glosses"] and len(existing["glosses"]) < 2:
+                            existing["glosses"].append(shown)
+                        continue
+                    items[key] = {
+                        "key": key,
+                        "glosses": [shown],
+                        "hint": item["hint"],
+                        "accept": item["accept"],
+                    }
+        if not items:
+            continue
+        for it in items.values():
+            vocab.update(it["accept"])
+        n_items += len(items)
+        out_words.append({
+            "word": w["word"],
+            "frequency_rank": w.get("frequency_rank"),
+            "items": list(items.values()),
+        })
+
+    payload = {
+        "_source": (
+            "Rection annotations from English Wiktionary Finnish verb glosses "
+            "(en.wiktionary.org, via the kaikki.org extract), CC BY-SA 4.0. "
+            "Parsed by scripts/extract_rection.py from data/verbs.json."
+        ),
+        "complements": sorted(vocab),
+        "words": out_words,
+    }
+    (DATA / "rection.json").write_text(
+        json.dumps(payload, ensure_ascii=False, indent=1), encoding="utf-8"
+    )
+
+    print(f"Wrote {len(out_words)} verbs, {n_items} rection items")
+    print(f"Complement vocabulary ({len(vocab)}): {', '.join(sorted(vocab))}")
+    for w in out_words[:8]:
+        for it in w["items"]:
+            hint = f" ‘{it['hint']}’" if it["hint"] else ""
+            print(f"  {w['word']:14s} + {' or '.join(it['accept'])}{hint}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sw.js
+++ b/sw.js
@@ -10,7 +10,7 @@
 // ⚠️ BUMP `CACHE_VERSION` whenever you ship app-shell changes that users need
 //    to pick up. Without a bump, they'll keep the old cached files forever.
 
-const CACHE_VERSION = "finnish-drill-v1.4.0";
+const CACHE_VERSION = "finnish-drill-v1.4.1";
 
 // Files required for the app to boot offline. Paths are relative so this
 // works under any base path (e.g. GitHub Pages project site).

--- a/sw.js
+++ b/sw.js
@@ -10,7 +10,7 @@
 // ⚠️ BUMP `CACHE_VERSION` whenever you ship app-shell changes that users need
 //    to pick up. Without a bump, they'll keep the old cached files forever.
 
-const CACHE_VERSION = "finnish-drill-v1.3.0";
+const CACHE_VERSION = "finnish-drill-v1.4.0";
 
 // Files required for the app to boot offline. Paths are relative so this
 // works under any base path (e.g. GitHub Pages project site).
@@ -42,6 +42,7 @@ const PRECACHE = [
   "./config/verb_groups.json",
   "./data/nouns.json",
   "./data/verbs.json",
+  "./data/rection.json",
   "./data/blocklist.json",
   "./icons/icon.svg",
 ];


### PR DESCRIPTION
## Summary

- Adds **Verb Rection** drill style (verb mode only): asks which complement a verb governs, answered by 4-option multiple choice. Data sourced entirely from Wiktionary annotations already in `data/verbs.json` — no AI-generated content.
- Adds `(beta)` label to both the **Cloze** and **Rection** drill-style buttons.
- Bumps app to **v1.4.1**; service worker cache version updated to match.

## What's included

- `scripts/extract_rection.py` — parses `[with illative 'in']`-style brackets from `data/verbs.json` into `data/rection.json` (89 verbs, 124 rection patterns, 15 complement types)
- `data/rection.json` — generated output, CC BY-SA 4.0 (Wiktionary)
- `js/drill.js` — `buildRectionPool()` with per-verb distractor exclusion
- `js/labels.js` — `complementLabel()`, `rectionLabel()`, `COMPLEMENT_LABELS`
- `js/data.js` — `loadRection()` with graceful fallback
- `js/stats.js` / `js/stats_ui.js` — `byRection` bucket, rection stats section
- `js/main.js` — rection rendering, multiple-choice interaction, keyboard shortcuts (1–4), auto-advance, `effectiveDrillStyle()` / `rectionActive()` / `statsMode()` helpers
- `index.html` — rection choices container, drill-style button updates, About section
- `css/style.css` — `.rection-choices` grid, `.rection-choice` button states, `.beta-tag` style
- `sw.js` / `js/version.js` — version bump to 1.4.1

## Test plan

- [ ] Switch to Verbs → select Rection → challenge shows verb + `___` blank + hint
- [ ] 4 complement buttons appear; picking correct one scores green and shows examples
- [ ] Picking wrong one scores red; correct answer highlighted; next challenge loads after 2s
- [ ] Keys 1–4 select options; Enter advances after resolve; `-` skips
- [ ] Rection button is hidden in Noun mode; switching back to Verbs restores it
- [ ] Cloze and Rection buttons both show `(beta)` tag in muted smaller text
- [ ] Stats page shows Rection section after drilling
- [ ] Service worker updates (cache version bumped)

https://claude.ai/code/session_01N5suKu1Emw3x3V4x5JTcSf

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5suKu1Emw3x3V4x5JTcSf)_