### PR TITLE
Add possessor person filter to Possessive drill

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -335,6 +335,10 @@ body.rection-mode #speak-answer,
 body.rection-mode #test-open,
 body.rection-mode #blitz-open { display: none; }
 
+/* Possessor filter section: hidden by default, shown only in possessive style. */
+.possessive-only { display: none; }
+body.possessive-mode .possessive-only { display: block; }
+
 .rection-choices {
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/js/drill.js
+++ b/js/drill.js
@@ -298,6 +298,7 @@ export function buildPossessivePool(data, nounFilters) {
     if (nounFilters?.groups && nounFilters.groups[pw.group] !== true) continue;
     const baseWord = nounMap.get(pw.word);
     for (const person of POSSESSIVE_PERSONS) {
+      if (nounFilters?.persons && nounFilters.persons[person] !== true) continue;
       const pInfl = (pw.inflections || {})[person];
       if (!pInfl) continue;
       for (const [caseKey, form] of Object.entries(pInfl)) {

--- a/js/filters.js
+++ b/js/filters.js
@@ -18,6 +18,14 @@ import * as storage from "./storage.js";
 const NOUN_KEY = "filters_noun_v1";
 const VERB_KEY = "filters_verb_v1";
 
+const POSSESSIVE_PERSONS = [
+  { id: "1sg", label: "1sg — my (minun)" },
+  { id: "2sg", label: "2sg — your (sinun)" },
+  { id: "3rd", label: "3rd — his / her / its (hänen)" },
+  { id: "1pl", label: "1pl — our (meidän)" },
+  { id: "2pl", label: "2pl — your pl. (teidän)" },
+];
+
 // =========================================================================
 // Defaults + load/save
 // =========================================================================
@@ -32,7 +40,9 @@ export function defaultNounFilters(cfg) {
   }
   const groups = {};
   for (const g of cfg.nounGroups.groups) groups[g.id] = true;
-  return { cases, groups };
+  const persons = {};
+  for (const p of POSSESSIVE_PERSONS) persons[p.id] = true;
+  return { cases, groups, persons };
 }
 
 export function defaultVerbFilters(cfg) {
@@ -99,6 +109,14 @@ export function renderNounFilters(root, cfg, state, onChange) {
   }
   groupSection.appendChild(list);
   root.appendChild(groupSection);
+
+  // Possessor persons — only relevant in Possessive drill style.
+  // CSS hides this section unless body.possessive-mode is active.
+  const personSection = simpleCheckboxSection(
+    "Possessor", POSSESSIVE_PERSONS, state.persons, changed, "group-list"
+  );
+  personSection.classList.add("possessive-only");
+  root.appendChild(personSection);
 }
 
 function renderCaseGrid(cfg, state, changed) {

--- a/js/main.js
+++ b/js/main.js
@@ -1539,10 +1539,12 @@ function updateAnswerPlaceholder() {
     : "type the form and press Enter";
 }
 
-// Swap the answer chrome for rection: CSS keyed off this body class hides the
-// text input and the hint buttons that assume a typed answer (Skip stays).
+// Swap body classes for mode-specific chrome.
+// rection-mode: hides the typed-answer input + hint buttons (multiple choice instead).
+// possessive-mode: reveals the Possessor filter section in the noun panel.
 function applyRectionChrome() {
-  document.body.classList.toggle("rection-mode", rectionActive());
+  document.body.classList.toggle("rection-mode",    rectionActive());
+  document.body.classList.toggle("possessive-mode", possessiveActive());
 }
 
 function setDrillStyle(style) {


### PR DESCRIPTION
Adds a **Possessor** checkbox section (1sg / 2sg / 3rd / 1pl / 2pl) to the noun filter panel so the Possessive drill can be narrowed to specific persons.

- Section is CSS-hidden by default and only revealed in the Possessive drill style (`body.possessive-mode`), so the Standard/Cloze noun view stays uncluttered
- `buildPossessivePool` respects the new `persons` filter dimension
- Persons default to all-on; existing saved filters pick up the new dimension via the storage merge

https://claude.ai/code/session_01N5suKu1Emw3x3V4x5JTcSf

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5suKu1Emw3x3V4x5JTcSf)_