### PR TITLE
Bump to v1.5.1 (SW cache bust for possessor filter)

### DIFF
--- a/js/version.js
+++ b/js/version.js
@@ -4,4 +4,4 @@
 // minor bump (1.x.0) for new features, major bump (x.0.0) for breaking
 // changes. Remember to also update CACHE_VERSION in sw.js to match.
 // (0.13 was skipped out of superstition; 1.3 ships anyway — owner's call.)
-export const APP_VERSION = "1.5.0";
+export const APP_VERSION = "1.5.1";

--- a/sw.js
+++ b/sw.js
@@ -10,7 +10,7 @@
 // ⚠️ BUMP `CACHE_VERSION` whenever you ship app-shell changes that users need
 //    to pick up. Without a bump, they'll keep the old cached files forever.
 
-const CACHE_VERSION = "finnish-drill-v1.5.0";
+const CACHE_VERSION = "finnish-drill-v1.5.1";
 
 // Files required for the app to boot offline. Paths are relative so this
 // works under any base path (e.g. GitHub Pages project site).


### PR DESCRIPTION
Follow-up to #12: that PR changed precached JS/CSS without bumping `CACHE_VERSION`, so the cache-first service worker would have served the old files to existing users indefinitely. Bumps app + cache version to 1.5.1 so clients pick up the possessor filter.

https://claude.ai/code/session_01N5suKu1Emw3x3V4x5JTcSf

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5suKu1Emw3x3V4x5JTcSf)_