### PR TITLE
Add KPT reference modal, grade highlighting, gradation filter, and rection button UX fix (v1.6.0)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -320,8 +320,16 @@ button.headword:hover { border-bottom-color: var(--accent); }
  * the card. The Rection button itself is hidden outside verb mode (JS). */
 .drill-style-row {
   display: flex;
+  align-items: center;
   justify-content: center;
+  gap: 0.5rem;
   margin-bottom: 0.75rem;
+}
+
+.kpt-btn {
+  font-size: 0.72rem;
+  padding: 0.25rem 0.5rem;
+  white-space: nowrap;
 }
 
 /* Rection drill style: the answer is one of four multiple-choice complement
@@ -927,6 +935,23 @@ kbd {
 .infl-empty    { color: var(--muted-soft); }
 .infl-target   { color: var(--accent); font-weight: 600; }
 .infl-masked   { color: var(--muted); letter-spacing: 0.15em; }
+.infl-weak     { color: var(--muted); font-style: italic; }
+
+/* KPT reference modal */
+.kpt-inner { max-width: 560px; }
+.kpt-intro { font-size: 0.88rem; color: var(--muted); margin-bottom: 1rem; }
+.kpt-body  { overflow-x: auto; }
+.kpt-table { width: 100%; }
+.kpt-strong { font-weight: 700; color: var(--accent); }
+.kpt-weak   { font-weight: 700; color: var(--muted); }
+
+/* Gradation filter — collapsible details block */
+.gradation-filter { border-top: 1px solid var(--border); padding-top: 0.6rem; margin-top: 0.25rem; }
+.gradation-filter summary { list-style: none; cursor: pointer; }
+.gradation-filter summary::-webkit-details-marker { display: none; }
+.gradation-summary { padding: 0; }
+.gradation-summary h2::before { content: "▶ "; font-size: 0.65em; opacity: 0.5; }
+details[open] .gradation-summary h2::before { content: "▼ "; }
 @media (max-width: 420px) {
   .infl-table { font-size: 0.8rem; }
   .infl-table th,

--- a/css/style.css
+++ b/css/style.css
@@ -369,12 +369,13 @@ body.possessive-mode .possessive-only { display: block; }
   transition: color var(--dur) var(--ease), border-color var(--dur) var(--ease),
               background var(--dur) var(--ease), transform 80ms var(--ease);
 }
-.rection-choice .choice-name {
-  flex: 1;
-}
 .rection-choice .choice-hint {
-  font-size: 0.8em;
-  opacity: 0.6;
+  flex: 1;
+  font-weight: 500;
+}
+.rection-choice .choice-name {
+  font-size: 0.75em;
+  opacity: 0.5;
   text-align: right;
   white-space: nowrap;
 }

--- a/index.html
+++ b/index.html
@@ -78,6 +78,7 @@
         <button type="button" class="seg-btn" data-value="possessive" role="radio">Possessive <span class="beta-tag">(beta)</span></button>
         <button type="button" class="seg-btn" data-value="rection"    role="radio">Rection <span class="beta-tag">(beta)</span></button>
       </div>
+      <button id="kpt-open" type="button" class="mini-btn kpt-btn" title="Consonant gradation reference">KPT</button>
     </div>
 
     <section id="challenge" class="panel challenge hidden">
@@ -134,6 +135,19 @@
         </button>
       </div>
     </section>
+
+    <!-- KPT reference modal: consonant gradation table, opened by the KPT
+         button in the drill-style row. Static content built by main.js. -->
+    <div id="kpt-modal" class="test-modal hidden" role="dialog" aria-labelledby="kpt-title" aria-modal="true">
+      <div class="test-modal-inner kpt-inner">
+        <h2 id="kpt-title">Consonant Gradation (KPT)</h2>
+        <p class="kpt-intro">Finnish alternates between a <strong>strong grade</strong> (nominative sg, infinitive) and a <strong>weak grade</strong> (genitive sg, most oblique cases, 1sg&nbsp;/&nbsp;2sg present).</p>
+        <div id="kpt-body" class="kpt-body"></div>
+        <div class="test-modal-actions">
+          <button id="kpt-close" type="button" class="mode-btn">Close</button>
+        </div>
+      </div>
+    </div>
 
     <!-- Full inflection table for the current word, opened by tapping the
          headword. Until the challenge is answered, cells matching the current

--- a/js/drill.js
+++ b/js/drill.js
@@ -5,6 +5,7 @@
 // so all filter logic is in one place.
 
 import { retrievability } from "./srs.js";
+import { detectNounGradation, detectVerbGradation } from "./gradation.js";
 
 function randomChoice(arr) {
   return arr[Math.floor(Math.random() * arr.length)];
@@ -26,6 +27,18 @@ function normalize(s) {
 
 // ---------- noun pool ----------
 
+// Returns true if the word passes the gradation dimension filter.
+// Only applies filtering when at least one pattern is unchecked; all-checked
+// (the default) skips detection entirely for performance.
+function passesGradeFilter(gf, detectFn, word) {
+  if (!gf) return true;
+  const allOn = Object.values(gf).every(Boolean);
+  if (allOn) return true;
+  const pat = detectFn(word);
+  const id  = pat ? pat.id : "none";
+  return gf[id] === true;
+}
+
 export function buildNounPool(data, filters) {
   const pool = [];
   for (const w of data.nouns.words) {
@@ -35,6 +48,7 @@ export function buildNounPool(data, filters) {
     // group ID not present in the filter map, or with no group at all),
     // which is why unchecking every box still produced challenges.
     if (filters && filters.groups && filters.groups[w.group] !== true) continue;
+    if (!passesGradeFilter(filters?.gradation, detectNounGradation, w)) continue;
     for (const key of Object.keys(w.inflections || {})) {
       // "Must be true" semantics — same reasoning as the group check above.
       // Some inflection keys in the data (e.g. instructive_singular on words
@@ -102,6 +116,7 @@ export function buildVerbPool(data, filters) {
   for (const w of data.verbs.words) {
     // Same "must be true" semantics as buildNounPool — see the note there.
     if (filters && filters.groups && filters.groups[w.group] !== true) continue;
+    if (!passesGradeFilter(filters?.gradation, detectVerbGradation, w)) continue;
     for (const key of Object.keys(w.inflections || {})) {
       if (filters && !verbKeyAllowed(key, filters)) continue;
       pool.push({ word: w, key });

--- a/js/filters.js
+++ b/js/filters.js
@@ -14,6 +14,7 @@
 //   }
 
 import * as storage from "./storage.js";
+import { GRADE_PATTERNS, GRADE_NONE } from "./gradation.js";
 
 const NOUN_KEY = "filters_noun_v1";
 const VERB_KEY = "filters_verb_v1";
@@ -42,7 +43,15 @@ export function defaultNounFilters(cfg) {
   for (const g of cfg.nounGroups.groups) groups[g.id] = true;
   const persons = {};
   for (const p of POSSESSIVE_PERSONS) persons[p.id] = true;
-  return { cases, groups, persons };
+  const gradation = defaultGradationDim();
+  return { cases, groups, persons, gradation };
+}
+
+function defaultGradationDim() {
+  const g = {};
+  for (const p of GRADE_PATTERNS) g[p.id] = true;
+  g[GRADE_NONE.id] = true;
+  return g;
 }
 
 export function defaultVerbFilters(cfg) {
@@ -52,6 +61,7 @@ export function defaultVerbFilters(cfg) {
     polarities: allOn(cfg.verbForms.polarities),
     persons:    allOn(cfg.verbForms.persons),
     groups:     allOn(cfg.verbGroups.groups),
+    gradation:  defaultGradationDim(),
   };
 }
 
@@ -117,6 +127,10 @@ export function renderNounFilters(root, cfg, state, onChange) {
   );
   personSection.classList.add("possessive-only");
   root.appendChild(personSection);
+
+  // Gradation filter — collapsed by default.
+  const gradeItems = [...GRADE_PATTERNS, GRADE_NONE];
+  root.appendChild(gradationSection(gradeItems, state.gradation, changed));
 }
 
 function renderCaseGrid(cfg, state, changed) {
@@ -220,11 +234,39 @@ export function renderVerbFilters(root, cfg, state, onChange) {
   root.appendChild(simpleCheckboxSection(
     "Verb type", cfg.verbGroups.groups, state.groups, changed, "group-list"
   ));
+
+  const gradeItems = [...GRADE_PATTERNS, GRADE_NONE];
+  root.appendChild(gradationSection(gradeItems, state.gradation, changed));
 }
 
 // =========================================================================
 // Shared helpers
 // =========================================================================
+
+// The gradation section is a collapsible <details> so it doesn't take up
+// space when the user isn't filtering by pattern.
+function gradationSection(items, stateDim, changed) {
+  const details = document.createElement("details");
+  details.className = "filter-section gradation-filter";
+  const summary = document.createElement("summary");
+  summary.className = "filter-section-head gradation-summary";
+  const h = document.createElement("h2");
+  h.textContent = "Gradation pattern";
+  summary.appendChild(h);
+  const btnAll = document.createElement("button");
+  btnAll.type = "button"; btnAll.textContent = "Select all"; btnAll.className = "mini-btn";
+  btnAll.addEventListener("click", (e) => { e.preventDefault(); toggleAll(stateDim, true);  changed(); });
+  const btnNone = document.createElement("button");
+  btnNone.type = "button"; btnNone.textContent = "Clear"; btnNone.className = "mini-btn";
+  btnNone.addEventListener("click", (e) => { e.preventDefault(); toggleAll(stateDim, false); changed(); });
+  summary.append(btnAll, btnNone);
+  details.appendChild(summary);
+  const list = document.createElement("div");
+  list.className = "group-list";
+  for (const it of items) list.appendChild(checkboxRow(it, stateDim, changed));
+  details.appendChild(list);
+  return details;
+}
 
 function simpleCheckboxSection(title, items, stateDim, changed, listClass) {
   const section = sectionWithHead(title,

--- a/js/gradation.js
+++ b/js/gradation.js
@@ -1,0 +1,93 @@
+// Consonant gradation (KPT) patterns and detection.
+//
+// Finnish consonant gradation alternates between a "strong grade" (nominative
+// singular, infinitive, etc.) and a "weak grade" (genitive singular, most
+// oblique cases, 1sg/2sg present, etc.).
+//
+// Detection compares consonant stems extracted from two well-defined forms:
+//   nouns: nominative_singular (strong) vs genitive_singular (weak)
+//   verbs: lemma / infinitive (strong) vs present_active_positive_1sg (weak)
+//
+// Longer patterns are listed before shorter ones so that "pp" is tested before
+// "p", preventing a false single-consonant match.
+
+export const GRADE_PATTERNS = [
+  { id: "pp_p",  strong: "pp", weak: "p",  label: "pp / p",
+    nounEx: "kauppa / kaupan",  verbEx: "—"               },
+  { id: "tt_t",  strong: "tt", weak: "t",  label: "tt / t",
+    nounEx: "katto / katon",    verbEx: "ottaa / otan"     },
+  { id: "kk_k",  strong: "kk", weak: "k",  label: "kk / k",
+    nounEx: "pankki / pankin",  verbEx: "nukkua / nukun"   },
+  { id: "mp_mm", strong: "mp", weak: "mm", label: "mp / mm",
+    nounEx: "lampi / lammen",   verbEx: "—"                },
+  { id: "nt_nn", strong: "nt", weak: "nn", label: "nt / nn",
+    nounEx: "ranta / rannan",   verbEx: "antaa / annan"    },
+  { id: "lt_ll", strong: "lt", weak: "ll", label: "lt / ll",
+    nounEx: "kulta / kullan",   verbEx: "—"                },
+  { id: "rt_rr", strong: "rt", weak: "rr", label: "rt / rr",
+    nounEx: "virta / virran",   verbEx: "—"                },
+  { id: "nk_ng", strong: "nk", weak: "ng", label: "nk / ng",
+    nounEx: "hanko / hangon",   verbEx: "—"                },
+  { id: "lk_l",  strong: "lk", weak: "l",  label: "lk / l",
+    nounEx: "sulka / sulan",    verbEx: "—"                },
+  { id: "rk_r",  strong: "rk", weak: "r",  label: "rk / r",
+    nounEx: "torku / torun",    verbEx: "—"                },
+  { id: "p_v",   strong: "p",  weak: "v",  label: "p / v",
+    nounEx: "haapa / haavan",   verbEx: "—"                },
+  { id: "t_d",   strong: "t",  weak: "d",  label: "t / d",
+    nounEx: "tauti / taudin",   verbEx: "tietää / tiedän"  },
+  { id: "k_0",   strong: "k",  weak: "",   label: "k / –",
+    nounEx: "jalka / jalan",    verbEx: "—"                },
+];
+
+// Sentinel for words with no detected gradation — used as a filter dimension.
+export const GRADE_NONE = { id: "none", label: "No gradation", strong: null, weak: null };
+
+// Strip trailing vowel cluster (to get consonant stem from nominative/infinitive).
+function trailingVowelStrip(s) {
+  return s.replace(/[aäoeöuyi]+$/, "");
+}
+
+// Strip final -Vn (vowel + n, genitive/1sg marker) to get consonant stem.
+function finalVnStrip(s) {
+  return s.replace(/[aäoeöuyi]n$/, "");
+}
+
+function matchPattern(sStem, wStem) {
+  if (!sStem || !wStem || sStem === wStem) return null;
+  for (const pat of GRADE_PATTERNS) {
+    if (!sStem.endsWith(pat.strong)) continue;
+    const prefix = sStem.slice(0, sStem.length - pat.strong.length);
+    if (wStem === prefix + pat.weak) return pat;
+  }
+  return null;
+}
+
+export function detectNounGradation(word) {
+  const nom = word.inflections?.nominative_singular || word.word;
+  const gen = word.inflections?.genitive_singular;
+  if (!nom || !gen) return null;
+  return matchPattern(trailingVowelStrip(nom), finalVnStrip(gen));
+}
+
+export function detectVerbGradation(word) {
+  const inf = word.word;
+  const sg1 = word.inflections?.present_active_positive_1sg;
+  if (!inf || !sg1) return null;
+  return matchPattern(trailingVowelStrip(inf), finalVnStrip(sg1));
+}
+
+// Return true if `form` uses the weak grade of `pattern`, given `strongCStem`
+// (the consonant stem derived from the strong-grade reference form).
+// Used to tint inflection-table cells.
+//
+// Strategy: form is weak-grade if it starts with (prefix + weakCluster) but
+// NOT with (prefix + strongCluster), where prefix is the invariant part before
+// the alternating consonant(s).
+export function isWeakGrade(form, pattern, strongCStem) {
+  if (!form || !pattern || pattern.strong === null) return false;
+  const prefix = strongCStem.slice(0, strongCStem.length - pattern.strong.length);
+  const wk = prefix + pattern.weak;
+  const st = prefix + pattern.strong;
+  return form.startsWith(wk) && !form.startsWith(st);
+}

--- a/js/main.js
+++ b/js/main.js
@@ -453,16 +453,16 @@ function renderRectionChoices() {
     const kbd = document.createElement("kbd");
     kbd.textContent = String(i + 1);
     btn.appendChild(kbd);
-    const nameEl = document.createElement("span");
-    nameEl.className = "choice-name";
-    nameEl.textContent = complementName(c);
-    btn.appendChild(nameEl);
     const h = complementHint(c);
+    const hintEl = document.createElement("span");
+    hintEl.className = "choice-hint";
+    hintEl.textContent = h || complementName(c);
+    btn.appendChild(hintEl);
     if (h) {
-      const hintEl = document.createElement("span");
-      hintEl.className = "choice-hint";
-      hintEl.textContent = h;
-      btn.appendChild(hintEl);
+      const nameEl = document.createElement("span");
+      nameEl.className = "choice-name";
+      nameEl.textContent = complementName(c);
+      btn.appendChild(nameEl);
     }
     if (resolved) {
       btn.disabled = true;

--- a/js/main.js
+++ b/js/main.js
@@ -30,6 +30,10 @@ import {
   loadBlitzStats, saveBlitzStats, recordBlitzRound, bestScoreAt, BLITZ_DURATIONS,
 } from "./blitz.js";
 import { APP_VERSION } from "./version.js";
+import {
+  GRADE_PATTERNS, GRADE_NONE,
+  detectNounGradation, detectVerbGradation, isWeakGrade,
+} from "./gradation.js";
 
 // Export-file schema version. Bumped only when the shape of the export
 // payload changes in a way that older code can't read directly — e.g. a key
@@ -187,6 +191,10 @@ const el = {
   blitzResultDone: document.getElementById("blitz-result-done"),
   blitzShareFeedback: document.getElementById("blitz-share-feedback"),
   settingShowBlitz:document.getElementById("setting-show-blitz"),
+  kptOpen:         document.getElementById("kpt-open"),
+  kptModal:        document.getElementById("kpt-modal"),
+  kptBody:         document.getElementById("kpt-body"),
+  kptClose:        document.getElementById("kpt-close"),
 };
 
 // ---------- rendering ----------
@@ -1612,7 +1620,7 @@ function closeInflectionTable() {
   if (state.view === "drill") el.answer.focus();
 }
 
-function inflectionCell(value, key, currentKey, expected, concealed) {
+function inflectionCell(value, key, currentKey, expected, concealed, gradeInfo) {
   const td = document.createElement("td");
   if (!value) {
     td.textContent = "—";
@@ -1620,7 +1628,13 @@ function inflectionCell(value, key, currentKey, expected, concealed) {
     return td;
   }
   if (key === currentKey) td.classList.add("infl-target");
-  if (concealed && value === expected) {
+  const masked = concealed && value === expected;
+  // Only tint when the cell isn't hidden — showing the grade class on a masked
+  // cell would leak that it's a weak/strong form before the answer is given.
+  if (!masked && gradeInfo && isWeakGrade(value, gradeInfo.pattern, gradeInfo.strongCStem)) {
+    td.classList.add("infl-weak");
+  }
+  if (masked) {
     td.classList.add("infl-masked");
     td.textContent = "•••";
     td.title = "hidden until you answer";
@@ -1649,6 +1663,11 @@ function inflectionTableSkeleton(headers) {
 
 function buildNounTable(word, currentKey, expected, concealed) {
   const { table, tbody } = inflectionTableSkeleton(["", "Singular", "Plural"]);
+  const gradePat  = detectNounGradation(word);
+  const strongCStem = gradePat
+    ? (word.inflections?.nominative_singular || word.word).replace(/[aäoeöuyi]+$/, "")
+    : null;
+  const gradeInfo = gradePat ? { pattern: gradePat, strongCStem } : null;
   for (const c of state.cfg.nounCases.cases) {
     const sg = word.inflections[`${c.id}_singular`];
     const pl = word.inflections[`${c.id}_plural`];
@@ -1658,8 +1677,8 @@ function buildNounTable(word, currentKey, expected, concealed) {
     th.scope = "row";
     th.textContent = c.label;
     tr.appendChild(th);
-    tr.appendChild(inflectionCell(sg, `${c.id}_singular`, currentKey, expected, concealed));
-    tr.appendChild(inflectionCell(pl, `${c.id}_plural`, currentKey, expected, concealed));
+    tr.appendChild(inflectionCell(sg, `${c.id}_singular`, currentKey, expected, concealed, gradeInfo));
+    tr.appendChild(inflectionCell(pl, `${c.id}_plural`,   currentKey, expected, concealed, gradeInfo));
     tbody.appendChild(tr);
   }
   return table;
@@ -1675,6 +1694,11 @@ const VERB_TABLE_PRONOUNS = {
 };
 
 function buildVerbTables(container, word, currentKey, expected, concealed) {
+  const gradePat    = detectVerbGradation(word);
+  const strongCStem = gradePat
+    ? word.word.replace(/[aäoeöuyi]+$/, "")
+    : null;
+  const gradeInfo = gradePat ? { pattern: gradePat, strongCStem } : null;
   const byTense = new Map(); // tenseId → { rowId → { positive: key, negative: key } }
   const nonFinite = [];
   for (const k of Object.keys(word.inflections || {})) {
@@ -1704,9 +1728,9 @@ function buildVerbTables(container, word, currentKey, expected, concealed) {
       th.textContent = VERB_TABLE_PRONOUNS[rowId] || rowId;
       tr.appendChild(th);
       tr.appendChild(inflectionCell(
-        word.inflections[slot.positive], slot.positive, currentKey, expected, concealed));
+        word.inflections[slot.positive], slot.positive, currentKey, expected, concealed, gradeInfo));
       tr.appendChild(inflectionCell(
-        word.inflections[slot.negative], slot.negative, currentKey, expected, concealed));
+        word.inflections[slot.negative], slot.negative, currentKey, expected, concealed, gradeInfo));
       tbody.appendChild(tr);
     }
     container.appendChild(table);
@@ -1723,7 +1747,7 @@ function buildVerbTables(container, word, currentKey, expected, concealed) {
       th.scope = "row";
       th.textContent = verbLabel(k, state.cfg);
       tr.appendChild(th);
-      tr.appendChild(inflectionCell(word.inflections[k], k, currentKey, expected, concealed));
+      tr.appendChild(inflectionCell(word.inflections[k], k, currentKey, expected, concealed, gradeInfo));
       tbody.appendChild(tr);
     }
     container.appendChild(table);
@@ -1833,6 +1857,49 @@ function removePreset(name) {
   deletePreset(state.presets, state.mode, name);
   savePresets(state.presets);
   renderPresets();
+}
+
+// ---------- KPT reference modal ----------
+
+function openKptModal() {
+  if (el.kptBody.childElementCount === 0) renderKptTable();
+  el.kptModal.classList.remove("hidden");
+}
+
+function closeKptModal() {
+  el.kptModal.classList.add("hidden");
+}
+
+function renderKptTable() {
+  const table = document.createElement("table");
+  table.className = "infl-table kpt-table";
+  const thead = document.createElement("thead");
+  const hr = document.createElement("tr");
+  for (const h of ["Strong", "Weak", "Noun (nom / gen)", "Verb (inf / 1sg)"]) {
+    const th = document.createElement("th");
+    th.textContent = h;
+    hr.appendChild(th);
+  }
+  thead.appendChild(hr);
+  table.appendChild(thead);
+  const tbody = document.createElement("tbody");
+  for (const p of GRADE_PATTERNS) {
+    const tr = document.createElement("tr");
+    const tdS = document.createElement("td");
+    tdS.textContent = p.strong;
+    tdS.className = "kpt-strong";
+    const tdW = document.createElement("td");
+    tdW.textContent = p.weak || "–";
+    tdW.className = "kpt-weak";
+    const tdN = document.createElement("td");
+    tdN.textContent = p.nounEx;
+    const tdV = document.createElement("td");
+    tdV.textContent = p.verbEx;
+    tr.append(tdS, tdW, tdN, tdV);
+    tbody.appendChild(tr);
+  }
+  table.appendChild(tbody);
+  el.kptBody.appendChild(table);
 }
 
 // ---------- boot ----------
@@ -2080,6 +2147,13 @@ async function boot() {
       setDrillStyle(btn.dataset.value);
     });
 
+    // KPT reference modal.
+    el.kptOpen.addEventListener("click", openKptModal);
+    el.kptClose.addEventListener("click", closeKptModal);
+    el.kptModal.addEventListener("click", (e) => {
+      if (e.target === el.kptModal) closeKptModal();
+    });
+
     // Full inflection table — opened by tapping the headword.
     el.headword.addEventListener("click", openInflectionTable);
     el.inflectionClose.addEventListener("click", closeInflectionTable);
@@ -2117,7 +2191,9 @@ async function boot() {
     // want the picker to steal focus from there.
     document.addEventListener("keydown", (e) => {
       if (e.key !== "Escape") return;
-      if (!el.inflectionModal.classList.contains("hidden")) {
+      if (!el.kptModal.classList.contains("hidden")) {
+        closeKptModal();
+      } else if (!el.inflectionModal.classList.contains("hidden")) {
         closeInflectionTable();
       } else if (!el.blitzStartModal.classList.contains("hidden")) {
         closeBlitzStartModal();

--- a/js/version.js
+++ b/js/version.js
@@ -4,4 +4,4 @@
 // minor bump (1.x.0) for new features, major bump (x.0.0) for breaking
 // changes. Remember to also update CACHE_VERSION in sw.js to match.
 // (0.13 was skipped out of superstition; 1.3 ships anyway — owner's call.)
-export const APP_VERSION = "1.5.1";
+export const APP_VERSION = "1.6.0";

--- a/sw.js
+++ b/sw.js
@@ -10,7 +10,7 @@
 // ⚠️ BUMP `CACHE_VERSION` whenever you ship app-shell changes that users need
 //    to pick up. Without a bump, they'll keep the old cached files forever.
 
-const CACHE_VERSION = "finnish-drill-v1.5.1";
+const CACHE_VERSION = "finnish-drill-v1.6.0";
 
 // Files required for the app to boot offline. Paths are relative so this
 // works under any base path (e.g. GitHub Pages project site).
@@ -23,6 +23,7 @@ const PRECACHE = [
   "./js/config.js",
   "./js/data.js",
   "./js/drill.js",
+  "./js/gradation.js",
   "./js/labels.js",
   "./js/filters.js",
   "./js/presets.js",


### PR DESCRIPTION
## Summary

- **KPT reference modal**: New button in the drill header opens a consonant gradation reference table showing all 13 strong/weak pairs with noun and verb examples
- **Weak grade highlighting**: Inflection table cells showing weak-grade forms are styled in muted italic, making the alternation pattern visible at a glance
- **Gradation filter**: New collapsible "Gradation" section in the noun and verb filter panels lets users drill only words with specific KPT patterns (or none)
- **Rection button UX**: Choice buttons now show the Finnish cue word (miltä, tekemään, -ksi) as the primary large text, with the grammar term (ablative, MA-inf. illative) as small secondary text — more learner-friendly

## Test plan

- [ ] Open the app, verify "KPT" button appears in the drill header
- [ ] Click KPT — modal opens with a table of 13 gradation patterns + "No gradation" row
- [ ] Open an inflected noun/verb table — weak-grade cells appear in muted italic
- [ ] Open noun/verb filters — "Gradation" section is present; unchecking patterns reduces the word pool
- [ ] Start a rection drill — buttons show Finnish question word (large) with grammar term (small, right-aligned)
- [ ] Verify version shows 1.6.0 in the app

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5suKu1Emw3x3V4x5JTcSf)_