### PR TITLE
v1.8.0: Merge adjectives into the noun pool

### DIFF
--- a/data/blocklist.json
+++ b/data/blocklist.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Words to drop from the drill pool. Update manually as junk entries are reported. Match is exact against the lemma. Categories: Finnish letter names (aa..öö), foreign letter names (he, jota...), music notes (as, es, b..h), all-caps abbreviations that decline with a colon (DNA:ssa), malformed/misspelled lemmas, proper nouns, multi-word phrases, and obscure dialect/synonym-of entries whose frequency rank comes from an unrelated homograph (e.g. the noun 'ja' = AND gate inherits rank 3 from the conjunction).",
+  "_comment": "Words to drop from the drill pool. Update manually as junk entries are reported. Match is exact against the lemma. Categories: Finnish letter names (aa..öö), foreign letter names (he, jota...), music notes (as, es, b..h), all-caps abbreviations that decline with a colon (DNA:ssa), malformed/misspelled lemmas, proper nouns, multi-word phrases, obscure dialect/synonym-of entries whose frequency rank comes from an unrelated homograph (e.g. the noun 'ja' = AND gate inherits rank 3 from the conjunction), and adjective superlative lemmas that are really common adverbs (takaisin, oikein, usein, öisin...) or archaic variants (parahin, kaunehin). Common comparatives/superlatives like parempi, paras, suurin are deliberately kept — their declension is worth drilling.",
   "nouns": [
     "aa", "dee", "ee", "ii", "koo", "oo", "pee", "see", "uu", "vee",
     "yy", "äl", "äm", "äs", "ää", "öö",
@@ -10,17 +10,24 @@
     "avo", "teka", "nro",
     "lontoo", "chester", "Lentokenttä", "Joulupukki", "t-paita",
     "oman onnensa seppä", "toissapäivä",
-    "ja", "vitu", "esi", "sii", "jotka", "aino", "anne", "iso", "onsi",
+    "ja", "vitu", "esi", "sii", "jotka", "aino", "anne", "onsi",
     "aion", "steve", "virhi", "jenny", "kati", "korja", "käsis", "louna",
     "palvi", "sei", "tomi", "perus", "pura", "nuke", "kallas", "verto",
     "kelle", "soni", "tantere", "puolus", "kiiri", "hämi", "dona", "mumma",
-    "kyynele", "kokoaja", "suljettu", "kirjoitin",
+    "kyynele", "kokoaja", "kirjoitin",
     "odottama", "vetämä", "nostama", "nousema", "laskema", "kasvama", "tarjoama",
     "juudas", "selus", "pieksu", "lieke", "kata", "merkintö", "face", "edus",
     "oppilapsi", "petra", "aurora", "nobel", "piiranen", "piira", "laskeutuma",
     "laksi", "perjantaki", "sunnuntaki", "lauantaki", "peni", "talka", "hapene",
     "live", "kuninkaanna", "leivo", "saga", "hyssykkä", "heavy", "passa",
-    "kaapeli-tv", "tappelus", "ex"
+    "kaapeli-tv", "tappelus", "ex",
+    "vaka", "kuulu", "vasempi", "käyvä", "naisinen", "iloisa", "katoava",
+    "huomaava", "helvetinmoinen", "suloisa", "kelpaava", "totteleva",
+    "rinnakas", "normaalinen",
+    "takaisin", "oikein", "voisin", "täysin", "kovin", "väärin", "usein",
+    "sekaisin", "tosin", "kotoisin", "aikaisin", "öisin", "iltaisin",
+    "aamuisin", "kesäisin", "viikonloppuisin", "rinnakkain", "jäisin",
+    "paljain", "jaloin", "parahin", "kaunehin", "rakkahin"
   ],
   "verbs": [
     "ei", "eikä", "tarvii", "dallaa", "seistä",

--- a/index.html
+++ b/index.html
@@ -308,8 +308,9 @@
       <ul>
         <li>
           <strong>Nouns</strong> &mdash; drills cases (nominative, genitive,
-          partitive, etc.) in singular and plural. Toggle cases in the grid or
-          limit the pool to specific KOTUS noun types.
+          partitive, etc.) in singular and plural. Adjectives are included in
+          the pool &mdash; they decline exactly like nouns. Toggle cases in
+          the grid or limit the pool to specific KOTUS noun types.
         </li>
         <li>
           <strong>Verbs</strong> &mdash; drills conjugations across tense,

--- a/js/version.js
+++ b/js/version.js
@@ -4,4 +4,4 @@
 // minor bump (1.x.0) for new features, major bump (x.0.0) for breaking
 // changes. Remember to also update CACHE_VERSION in sw.js to match.
 // (0.13 was skipped out of superstition; 1.3 ships anyway — owner's call.)
-export const APP_VERSION = "1.7.0";
+export const APP_VERSION = "1.8.0";

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -25,12 +25,17 @@ pip install -r scripts/requirements.txt
 ```
 python scripts/download.py              # grabs kaikki.org data + frequency list
 python scripts/extract.py               # filters and writes data/nouns.json + verbs.json
+                                        # (adjectives are merged into nouns.json —
+                                        # they decline identically)
 python scripts/extract_rection.py       # rection annotations → data/rection.json
 python scripts/extract_possessives.py   # possessive paradigms → data/possessives.json
 python scripts/extract_numerals.py      # numeral paradigms → data/numerals.json
 python scripts/gen_compound_numerals.py # fills in any 11-19 / tens missing from
                                         # Wiktionary by composing base paradigms
                                         # (no raw dump needed)
+python scripts/extract_tatoeba.py       # tops up example sentences in nouns.json
+                                        # + verbs.json from Tatoeba (run after
+                                        # extract.py; downloads ~150 MB once)
 ```
 
 Re-run these when you want fresh words or change filters (e.g. `FREQUENCY_CUTOFF`

--- a/scripts/extract.py
+++ b/scripts/extract.py
@@ -394,7 +394,12 @@ def main() -> int:
     for entry in iter_entries(KAIKKI_FILE):
         pos = entry.get("pos")
         word = entry.get("word")
-        if not word or pos not in ("noun", "verb"):
+        # Adjectives decline exactly like nouns (same KOTUS classes, same case
+        # endings, same gradation), so they go through the noun machinery and
+        # are merged into the noun pool — no separate drill or data file.
+        # Comparative/superlative rows in their tables carry no case+number
+        # tags, so noun_form_key() drops them automatically.
+        if not word or pos not in ("noun", "adj", "verb"):
             continue
         counts[f"seen_{pos}"] += 1
 
@@ -425,9 +430,10 @@ def main() -> int:
             counts[f"junk_{pos}"] += 1
             continue
 
-        tpl_map = noun_tpl if pos == "noun" else verb_tpl
-        group_of = noun_group_of if pos == "noun" else verb_group_of
-        shaper = shape_noun if pos == "noun" else shape_verb
+        nounlike = pos in ("noun", "adj")
+        tpl_map = noun_tpl if nounlike else verb_tpl
+        group_of = noun_group_of if nounlike else verb_group_of
+        shaper = shape_noun if nounlike else shape_verb
 
         ktype = extract_kotus_type(entry, tpl_map)
         if ktype is None:
@@ -441,7 +447,7 @@ def main() -> int:
             counts[f"no_inflections_{pos}"] += 1
             continue
         shaped["frequency_rank"] = rank
-        (nouns if pos == "noun" else verbs).append(shaped)
+        (nouns if nounlike else verbs).append(shaped)
 
     # Deduplicate by word (keep the one with most inflection entries).
     def dedupe(items: list[dict]) -> list[dict]:
@@ -475,7 +481,8 @@ def main() -> int:
     print("Counts:", dict(counts))
 
     # Sanity check: show inflection key counts for a handful of common lemmas.
-    sample_nouns = {"kala", "talo", "nainen", "k\u00e4si", "vastaus"}
+    sample_nouns = {"kala", "talo", "nainen", "k\u00e4si", "vastaus",
+                    "hyv\u00e4", "pieni", "suuri", "uusi", "kaunis"}
     sample_verbs = {"sanoa", "olla", "tehd\u00e4", "menn\u00e4", "puhua"}
     print("\nSanity check — inflection keys extracted for sample lemmas:")
     for n in nouns:

--- a/sw.js
+++ b/sw.js
@@ -10,7 +10,7 @@
 // ⚠️ BUMP `CACHE_VERSION` whenever you ship app-shell changes that users need
 //    to pick up. Without a bump, they'll keep the old cached files forever.
 
-const CACHE_VERSION = "finnish-drill-v1.7.0";
+const CACHE_VERSION = "finnish-drill-v1.8.0";
 
 // Files required for the app to boot offline. Paths are relative so this
 // works under any base path (e.g. GitHub Pages project site).


### PR DESCRIPTION
## Summary

- **Adjectives are now drillable.** `extract.py` accepts `pos=adj` and runs adjective entries through the existing noun machinery into `nouns.json` — they decline identically (same KOTUS classes, case endings, gradation), so there's no separate drill, filter, or data file. Comparison rows (*pienempi, pienin*) carry no case+number tags and are dropped automatically.
- **Noun pool: 4,436 → 5,621 words** (5,500 drillable after blocklist; 141,529 inflection slots). All core adjectives present with full 26-form paradigms and example sentences.
- **Curation pass over the new entries** (37 blocks, 2 unblocks):
  - Unblocked *iso* and *suljettu* — their junk noun homographs lost dedupe to the legitimate adjectives
  - Kept common comparative/superlative lemmas (*parempi, paras, suurin, tärkein*) — comparative declension is worth drilling
  - Blocked superlatives that are really adverbs with contaminated ranks (*takaisin, oikein, täysin, usein, öisin*…), verb-form homographs (*voisin, jäisin*), archaic variants (*parahin, kaunehin*), and rare synonym-of dialect variants (*vaka, iloisa, suloisa*…)
- Possessives stay noun-only (`extract_possessives.py` already filters `pos=noun`), so no awkward *pieneni*-style drills
- Updated in-app help text and pipeline README (which was also missing the Tatoeba step)

## Test plan

- [ ] App loads and shows v1.8.0 in footer
- [ ] Noun drill serves adjectives (*hyvä, pieni, suuri, kaunis*…) with correct case forms
- [ ] *iso* and *suljettu* appear in the pool; *takaisin/oikein/usein* do not
- [ ] Comparatives decline correctly (*parempi* → *paremman*, *suurin* → *suurimmassa*)
- [ ] KOTUS group filters include adjectives in their declension classes

https://claude.ai/code/session_01N5suKu1Emw3x3V4x5JTcSf

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5suKu1Emw3x3V4x5JTcSf)_